### PR TITLE
Implement warnOnceLoggerProvider

### DIFF
--- a/wlog/logger_provider.go
+++ b/wlog/logger_provider.go
@@ -16,50 +16,9 @@ package wlog
 
 import (
 	"io"
-	"reflect"
 )
 
 type LoggerProvider interface {
 	NewLogger(w io.Writer) Logger
 	NewLeveledLogger(w io.Writer, level LogLevel) LeveledLogger
 }
-
-// NewNoopLoggerProvider returns a LoggerProvider whose implementations
-// are no-ops. That is, they return immediately after doing nothing.
-func NewNoopLoggerProvider() LoggerProvider {
-	return &noopLoggerProvider{}
-}
-
-type nooplogger struct{}
-
-func (*nooplogger) Log(params ...Param)               {}
-func (*nooplogger) Debug(msg string, params ...Param) {}
-func (*nooplogger) Info(msg string, params ...Param)  {}
-func (*nooplogger) Warn(msg string, params ...Param)  {}
-func (*nooplogger) Error(msg string, params ...Param) {}
-func (*nooplogger) SetLevel(level LogLevel)           {}
-
-type noopLoggerProvider struct{}
-
-func (*noopLoggerProvider) NewLogger(w io.Writer) Logger {
-	return &nooplogger{}
-}
-
-func (*noopLoggerProvider) NewLeveledLogger(w io.Writer, level LogLevel) LeveledLogger {
-	return &nooplogger{}
-}
-
-func (p *noopLoggerProvider) NewLogEntry() LogEntry {
-	return &noopLogEntry{}
-}
-
-type noopLogEntry struct{}
-
-func (*noopLogEntry) StringValue(k, v string)                                         {}
-func (*noopLogEntry) OptionalStringValue(k, v string)                                 {}
-func (*noopLogEntry) StringListValue(k string, v []string)                            {}
-func (*noopLogEntry) SafeLongValue(k string, v int64)                                 {}
-func (*noopLogEntry) IntValue(k string, v int32)                                      {}
-func (*noopLogEntry) StringMapValue(k string, v map[string]string)                    {}
-func (*noopLogEntry) AnyMapValue(k string, v map[string]interface{})                  {}
-func (*noopLogEntry) ObjectValue(k string, v interface{}, marshalerType reflect.Type) {}

--- a/wlog/logger_provider_noop.go
+++ b/wlog/logger_provider_noop.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wlog
+
+import (
+	"io"
+	"reflect"
+)
+
+// NewNoopLoggerProvider returns a LoggerProvider whose implementations
+// are no-ops. That is, they return immediately after doing nothing.
+func NewNoopLoggerProvider() LoggerProvider {
+	return &noopLoggerProvider{}
+}
+
+type nooplogger struct{}
+
+func (*nooplogger) Log(params ...Param)               {}
+func (*nooplogger) Debug(msg string, params ...Param) {}
+func (*nooplogger) Info(msg string, params ...Param)  {}
+func (*nooplogger) Warn(msg string, params ...Param)  {}
+func (*nooplogger) Error(msg string, params ...Param) {}
+func (*nooplogger) SetLevel(level LogLevel)           {}
+
+type noopLoggerProvider struct{}
+
+func (*noopLoggerProvider) NewLogger(w io.Writer) Logger {
+	return &nooplogger{}
+}
+
+func (*noopLoggerProvider) NewLeveledLogger(w io.Writer, level LogLevel) LeveledLogger {
+	return &nooplogger{}
+}
+
+func (p *noopLoggerProvider) NewLogEntry() LogEntry {
+	return &noopLogEntry{}
+}
+
+type noopLogEntry struct{}
+
+func (*noopLogEntry) StringValue(k, v string)                                         {}
+func (*noopLogEntry) OptionalStringValue(k, v string)                                 {}
+func (*noopLogEntry) StringListValue(k string, v []string)                            {}
+func (*noopLogEntry) SafeLongValue(k string, v int64)                                 {}
+func (*noopLogEntry) IntValue(k string, v int32)                                      {}
+func (*noopLogEntry) StringMapValue(k string, v map[string]string)                    {}
+func (*noopLogEntry) AnyMapValue(k string, v map[string]interface{})                  {}
+func (*noopLogEntry) ObjectValue(k string, v interface{}, marshalerType reflect.Type) {}

--- a/wlog/logger_provider_warnonce.go
+++ b/wlog/logger_provider_warnonce.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wlog
+
+import (
+	"fmt"
+	"io"
+	"sync"
+)
+
+// TODO(nmiyake): remove this once logger is used in project
+var _ = newWarnOnceLoggerProvider()
+
+func newWarnOnceLoggerProvider() LoggerProvider {
+	return &warnOnceLoggerProvider{}
+}
+
+type warnOnceLogger struct {
+	w    io.Writer
+	once sync.Once
+}
+
+func (l *warnOnceLogger) Log(params ...Param)               { l.once.Do(l.printWarning) }
+func (l *warnOnceLogger) Debug(msg string, params ...Param) { l.once.Do(l.printWarning) }
+func (l *warnOnceLogger) Info(msg string, params ...Param)  { l.once.Do(l.printWarning) }
+func (l *warnOnceLogger) Warn(msg string, params ...Param)  { l.once.Do(l.printWarning) }
+func (l *warnOnceLogger) Error(msg string, params ...Param) { l.once.Do(l.printWarning) }
+func (l *warnOnceLogger) SetLevel(level LogLevel)           { l.once.Do(l.printWarning) }
+
+func (l *warnOnceLogger) printWarning() {
+	_, _ = fmt.Fprintln(l.w,
+		`[WARNING] Logging operation that uses the default logger provider was performed without specifying a logger provider implementation.`+"\n"+
+			`          To see logger output, set the global tracer implementation using wlog.SetDefaultLoggerProvider or by importing an implementation.`+"\n"+
+			`          This warning can be disabled by setting the global logger provider to be the noop logger provider using wlog.SetDefaultLoggerProvider(wlog.NewNoopLoggerProvider()).`,
+	)
+}
+
+type warnOnceLoggerProvider struct{}
+
+func (*warnOnceLoggerProvider) NewLogger(w io.Writer) Logger {
+	return &warnOnceLogger{
+		w: w,
+	}
+}
+
+func (*warnOnceLoggerProvider) NewLeveledLogger(w io.Writer, level LogLevel) LeveledLogger {
+	return &warnOnceLogger{
+		w: w,
+	}
+}
+
+func (*warnOnceLoggerProvider) NewLogEntry() LogEntry {
+	return &noopLogEntry{}
+}

--- a/wlog/logger_provider_warnonce_test.go
+++ b/wlog/logger_provider_warnonce_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wlog
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Verifies that a logger created by newWarnOnceLoggerProvider outputs a warning on the first log call but not on
+// subsequent calls.
+func TestWarnOnceProvider(t *testing.T) {
+	const wantOutput = `[WARNING] Logging operation that uses the default logger provider was performed without specifying a logger provider implementation.` + "\n" +
+		`          To see logger output, set the global tracer implementation using wlog.SetDefaultLoggerProvider or by importing an implementation.` + "\n" +
+		`          This warning can be disabled by setting the global logger provider to be the noop logger provider using wlog.SetDefaultLoggerProvider(wlog.NewNoopLoggerProvider()).` + "\n"
+	provider := newWarnOnceLoggerProvider()
+
+	buf := &bytes.Buffer{}
+	logger := provider.NewLogger(buf)
+
+	logger.Log()
+	assert.Equal(t, wantOutput, buf.String())
+
+	buf.Reset()
+	logger.Log()
+	assert.Equal(t, "", buf.String())
+}


### PR DESCRIPTION
Adds a new logger provider type that creates loggers that print
a warning about the logger provider not being set. This warning is
printed once per created logger.