### PR TITLE
Use the warn-once logger provider as the default logger provider

### DIFF
--- a/wlog/logger_provider_default.go
+++ b/wlog/logger_provider_default.go
@@ -14,7 +14,7 @@
 
 package wlog
 
-var defaultLoggerProvider = NewNoopLoggerProvider()
+var defaultLoggerProvider = newWarnOnceLoggerProvider()
 
 func SetDefaultLoggerProvider(provider LoggerProvider) {
 	defaultLoggerProvider = provider

--- a/wlog/logger_provider_default_test.go
+++ b/wlog/logger_provider_default_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wlog_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/palantir/witchcraft-go-logging/wlog"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/stretchr/testify/assert"
+)
+
+// Verifies that a logger created using the default logger provider uses the newWarnOnceLoggerProvider.
+//
+// Note that this test depends on the global state of defaultLoggerProvider: if the default logger is set before this
+// test is run in the same process or if the default logger provider is changed in the future, the test will fail.
+func TestDefaultProviderIsWarnOnceProvider(t *testing.T) {
+	// create logger that writes to buffer using the default logger provider
+	buf := &bytes.Buffer{}
+	logger := svc1log.New(buf, wlog.DebugLevel) // uses default provider
+
+	// verify that output provides warning that no logger provider was specified
+	logger.Info("Test output 1")
+	const wantOutput = `[WARNING] Logging operation that uses the default logger provider was performed without specifying a logger provider implementation.` + "\n" +
+		`          To see logger output, set the global tracer implementation using wlog.SetDefaultLoggerProvider or by importing an implementation.` + "\n" +
+		`          This warning can be disabled by setting the global logger provider to be the noop logger provider using wlog.SetDefaultLoggerProvider(wlog.NewNoopLoggerProvider()).` + "\n"
+	got := buf.String()
+	assert.Equal(t, wantOutput, got)
+
+	// verify that warning is only written on first call to logger
+	logger.Info("Test output 2")
+	buf.Reset()
+	got = buf.String()
+	assert.Equal(t, "", got)
+}

--- a/wlog/logger_provider_warnonce.go
+++ b/wlog/logger_provider_warnonce.go
@@ -20,9 +20,6 @@ import (
 	"sync"
 )
 
-// TODO(nmiyake): remove this once logger is used in project
-var _ = newWarnOnceLoggerProvider()
-
 func newWarnOnceLoggerProvider() LoggerProvider {
 	return &warnOnceLoggerProvider{}
 }


### PR DESCRIPTION
Previously, the noop provider was used as the default provider,
which meant that if a logger provider was not set, loggers would not
output anything. The noop provider implementation remains so that
users can explicitly set the default logger provider to the noop one
if that is the behavior they want.