### PR TITLE
Create JSON marshal logger provider and use in tests

### DIFF
--- a/wlog/auditlog/audit2log/context_test.go
+++ b/wlog/auditlog/audit2log/context_test.go
@@ -17,11 +17,8 @@ package audit2log_test
 import (
 	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
 	"testing"
-	"time"
 
 	"github.com/palantir/pkg/objmatcher"
 	"github.com/palantir/witchcraft-go-logging/wlog"
@@ -34,26 +31,7 @@ import (
 )
 
 func newTestLogger(w io.Writer) audit2log.Logger {
-	return &testAudit2Logger{
-		w: w,
-	}
-}
-
-type testAudit2Logger struct {
-	w io.Writer
-}
-
-func (l *testAudit2Logger) Audit(name string, result audit2log.AuditResultType, params ...audit2log.Param) {
-	entry := wlog.NewMapLogEntry()
-	entry.StringValue(wlog.TypeKey, audit2log.TypeValue)
-	entry.StringValue(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
-	entry.StringValue(audit2log.NameKey, name)
-	entry.StringValue(audit2log.ResultKey, string(result))
-	for _, p := range params {
-		audit2log.ApplyParam(p, entry)
-	}
-	jsonBytes, _ := json.Marshal(entry.AllValues())
-	fmt.Fprintln(l.w, string(jsonBytes))
+	return audit2log.NewFromCreator(w, wlog.NewJSONMarshalLoggerProvider().NewLogger)
 }
 
 func TestFromContext(t *testing.T) {

--- a/wlog/evtlog/evt2log/context_test.go
+++ b/wlog/evtlog/evt2log/context_test.go
@@ -17,11 +17,8 @@ package evt2log_test
 import (
 	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
 	"testing"
-	"time"
 
 	"github.com/palantir/pkg/objmatcher"
 	"github.com/palantir/witchcraft-go-logging/wlog"
@@ -34,25 +31,7 @@ import (
 )
 
 func newTestLogger(w io.Writer) evt2log.Logger {
-	return &testEvent2Logger{
-		w: w,
-	}
-}
-
-type testEvent2Logger struct {
-	w io.Writer
-}
-
-func (l *testEvent2Logger) Event(name string, params ...evt2log.Param) {
-	entry := wlog.NewMapLogEntry()
-	entry.StringValue(wlog.TypeKey, evt2log.TypeValue)
-	entry.StringValue(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
-	entry.StringValue(evt2log.EventNameKey, name)
-	for _, p := range params {
-		evt2log.ApplyParam(p, entry)
-	}
-	jsonBytes, _ := json.Marshal(entry.AllValues())
-	fmt.Fprintln(l.w, string(jsonBytes))
+	return evt2log.NewFromCreator(w, wlog.NewJSONMarshalLoggerProvider().NewLogger)
 }
 
 func TestFromContext(t *testing.T) {

--- a/wlog/logger_provider_jsonmarshal.go
+++ b/wlog/logger_provider_jsonmarshal.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wlog
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// NewJSONMarshalLoggerProvider returns a new logger provider that uses a MapLogEntry as its log entry and performs
+// logging by performing a json.Marshal of the MapLogEntry. This is a naive implementation that is not very efficient:
+// its primary purpose is for tests and in-memory usage in scenarios where one does not want to use a logger provider
+// that uses an external library.
+func NewJSONMarshalLoggerProvider() LoggerProvider {
+	return &jsonMarshalLoggerProvider{}
+}
+
+type jsonMapLogger struct {
+	w     io.Writer
+	level LogLevel
+}
+
+func (l *jsonMapLogger) Log(params ...Param) {
+	l.logOutput(params)
+}
+
+func (l *jsonMapLogger) Debug(msg string, params ...Param) {
+	switch l.level {
+	case DebugLevel:
+		l.logOutputWithMessage(msg, "DEBUG", params)
+	}
+}
+
+func (l *jsonMapLogger) Info(msg string, params ...Param) {
+	switch l.level {
+	case DebugLevel, InfoLevel:
+		l.logOutputWithMessage(msg, "INFO", params)
+	}
+}
+
+func (l *jsonMapLogger) Warn(msg string, params ...Param) {
+	switch l.level {
+	case DebugLevel, InfoLevel, WarnLevel:
+		l.logOutputWithMessage(msg, "WARN", params)
+	}
+}
+
+func (l *jsonMapLogger) Error(msg string, params ...Param) {
+	switch l.level {
+	case DebugLevel, InfoLevel, WarnLevel, ErrorLevel:
+		l.logOutputWithMessage(msg, "ERROR", params)
+	}
+}
+
+func (l *jsonMapLogger) SetLevel(level LogLevel) {
+	l.level = level
+}
+
+func (l *jsonMapLogger) logOutputWithMessage(msg, level string, params []Param) {
+	l.logOutput(append(params, StringParam("message", msg), StringParam("level", level)))
+}
+
+func (l *jsonMapLogger) logOutput(params []Param) {
+	params = append(params, StringParam(TimeKey, time.Now().Format(time.RFC3339Nano)))
+
+	entry := NewMapLogEntry()
+	ApplyParams(entry, params)
+	bytes, _ := json.Marshal(entry.AllValues())
+	fmt.Fprintln(l.w, string(bytes))
+}
+
+type jsonMarshalLoggerProvider struct{}
+
+func (*jsonMarshalLoggerProvider) NewLogger(w io.Writer) Logger {
+	return &jsonMapLogger{
+		w: w,
+	}
+}
+
+func (*jsonMarshalLoggerProvider) NewLeveledLogger(w io.Writer, level LogLevel) LeveledLogger {
+	return &jsonMapLogger{
+		w:     w,
+		level: level,
+	}
+}
+
+func (p *jsonMarshalLoggerProvider) NewLogEntry() LogEntry {
+	return NewMapLogEntry()
+}

--- a/wlog/metriclog/metric1log/context_test.go
+++ b/wlog/metriclog/metric1log/context_test.go
@@ -17,11 +17,8 @@ package metric1log_test
 import (
 	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
 	"testing"
-	"time"
 
 	"github.com/palantir/pkg/objmatcher"
 	"github.com/palantir/witchcraft-go-logging/wlog"
@@ -32,26 +29,7 @@ import (
 )
 
 func newTestLogger(w io.Writer) metric1log.Logger {
-	return &testMetric1Logger{
-		w: w,
-	}
-}
-
-type testMetric1Logger struct {
-	w io.Writer
-}
-
-func (l *testMetric1Logger) Metric(name, typ string, params ...metric1log.Param) {
-	entry := wlog.NewMapLogEntry()
-	entry.StringValue(wlog.TypeKey, metric1log.TypeValue)
-	entry.StringValue(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
-	entry.StringValue(metric1log.MetricNameKey, name)
-	entry.StringValue(metric1log.MetricTypeKey, typ)
-	for _, p := range params {
-		metric1log.ApplyParam(p, entry)
-	}
-	jsonBytes, _ := json.Marshal(entry.AllValues())
-	fmt.Fprintln(l.w, string(jsonBytes))
+	return metric1log.NewFromCreator(w, wlog.NewJSONMarshalLoggerProvider().NewLogger)
 }
 
 func TestFromContext(t *testing.T) {

--- a/wlog/svclog/svc1log/context_test.go
+++ b/wlog/svclog/svc1log/context_test.go
@@ -18,10 +18,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"testing"
-	"time"
 
 	"github.com/palantir/pkg/objmatcher"
 	"github.com/palantir/witchcraft-go-logging/wlog"
@@ -35,47 +33,7 @@ import (
 )
 
 func newTestLogger(w io.Writer, origin string) svc1log.Logger {
-	return &testSvc1Logger{
-		w:      w,
-		origin: origin,
-	}
-}
-
-type testSvc1Logger struct {
-	origin string
-	w      io.Writer
-}
-
-func (l *testSvc1Logger) Debug(msg string, params ...svc1log.Param) {
-	l.log(msg, "DEBUG", params...)
-}
-
-func (l *testSvc1Logger) Info(msg string, params ...svc1log.Param) {
-	l.log(msg, "INFO", params...)
-}
-
-func (l *testSvc1Logger) Warn(msg string, params ...svc1log.Param) {
-	l.log(msg, "WARN", params...)
-}
-
-func (l *testSvc1Logger) Error(msg string, params ...svc1log.Param) {
-	l.log(msg, "ERROR", params...)
-}
-
-func (l *testSvc1Logger) SetLevel(level wlog.LogLevel) {}
-
-func (l *testSvc1Logger) log(msg, lvl string, params ...svc1log.Param) {
-	entry := wlog.NewMapLogEntry()
-	entry.StringValue(wlog.TypeKey, svc1log.TypeValue)
-	entry.StringValue(svc1log.MessageKey, msg)
-	entry.StringValue(svc1log.LevelKey, lvl)
-	entry.StringValue(svc1log.OriginKey, l.origin)
-	entry.StringValue(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
-	for _, p := range params {
-		svc1log.ApplyParam(p, entry)
-	}
-	jsonBytes, _ := json.Marshal(entry.AllValues())
-	fmt.Fprintln(l.w, string(jsonBytes))
+	return svc1log.WithParams(svc1log.NewFromCreator(w, wlog.InfoLevel, wlog.NewJSONMarshalLoggerProvider().NewLeveledLogger), svc1log.Origin(origin))
 }
 
 func TestFromContext(t *testing.T) {


### PR DESCRIPTION
Reduces amount of boilerplate code needed in logger tests.