### PR TITLE
Update default warning logger output to be a single line

### DIFF
--- a/wlog/logger_provider_default_test.go
+++ b/wlog/logger_provider_default_test.go
@@ -34,7 +34,7 @@ func TestDefaultProviderIsWarnOnceProvider(t *testing.T) {
 
 	// verify that output provides warning that no logger provider was specified
 	logger.Info("Test output 1")
-	const wantOutput = `[WARNING] Logging operation that uses the default logger provider was performed without specifying a logger provider implementation. To see logger output, set the global tracer implementation using wlog.SetDefaultLoggerProvider or by importing an implementation. This warning can be disabled by setting the global logger provider to be the noop logger provider using wlog.SetDefaultLoggerProvider(wlog.NewNoopLoggerProvider()).` + "\n"
+	const wantOutput = `[WARNING] Logging operation that uses the default logger provider was performed without specifying a logger provider implementation. To see logger output, set the global logger provider implementation using wlog.SetDefaultLoggerProvider or by importing an implementation. This warning can be disabled by setting the global logger provider to be the noop logger provider using wlog.SetDefaultLoggerProvider(wlog.NewNoopLoggerProvider()).` + "\n"
 	got := buf.String()
 	assert.Equal(t, wantOutput, got)
 

--- a/wlog/logger_provider_warnonce.go
+++ b/wlog/logger_provider_warnonce.go
@@ -38,7 +38,7 @@ func (l *warnOnceLogger) SetLevel(level LogLevel)           { l.once.Do(l.printW
 
 func (l *warnOnceLogger) printWarning() {
 	_, _ = fmt.Fprintln(l.w, `[WARNING] Logging operation that uses the default logger provider was performed without specifying a logger provider implementation. `+
-		`To see logger output, set the global tracer implementation using wlog.SetDefaultLoggerProvider or by importing an implementation. `+
+		`To see logger output, set the global logger provider implementation using wlog.SetDefaultLoggerProvider or by importing an implementation. `+
 		`This warning can be disabled by setting the global logger provider to be the noop logger provider using wlog.SetDefaultLoggerProvider(wlog.NewNoopLoggerProvider()).`)
 }
 

--- a/wlog/logger_provider_warnonce_test.go
+++ b/wlog/logger_provider_warnonce_test.go
@@ -24,7 +24,7 @@ import (
 // Verifies that a logger created by newWarnOnceLoggerProvider outputs a warning on the first log call but not on
 // subsequent calls.
 func TestWarnOnceProvider(t *testing.T) {
-	const wantOutput = `[WARNING] Logging operation that uses the default logger provider was performed without specifying a logger provider implementation. To see logger output, set the global tracer implementation using wlog.SetDefaultLoggerProvider or by importing an implementation. This warning can be disabled by setting the global logger provider to be the noop logger provider using wlog.SetDefaultLoggerProvider(wlog.NewNoopLoggerProvider()).` + "\n"
+	const wantOutput = `[WARNING] Logging operation that uses the default logger provider was performed without specifying a logger provider implementation. To see logger output, set the global logger provider implementation using wlog.SetDefaultLoggerProvider or by importing an implementation. This warning can be disabled by setting the global logger provider to be the noop logger provider using wlog.SetDefaultLoggerProvider(wlog.NewNoopLoggerProvider()).` + "\n"
 	provider := newWarnOnceLoggerProvider()
 
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
Maintains the precondition that logger output should only be on a
single line, which is required for general parsing logic.