### PR TITLE
Add better handling for default loggers extracted from contexts

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,14 @@
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  branch = "develop"
+  digest = "1:e3ef56367b26bd9af40cc27ea3ae48efdca309b10ed5859bc6289a40a53c3143"
+  name = "github.com/nmiyake/pkg"
+  packages = ["dirs"]
+  pruneopts = "UT"
+  revision = "b64318170fdef93b4462420e0badef8050dbb7ec"
+
+[[projects]]
   digest = "1:fe3dbc20b592ad7cac16a2855ee7505edf07e4f9feb47e78e40a39f2270386b8"
   name = "github.com/openzipkin/zipkin-go"
   packages = [
@@ -147,6 +155,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/golang/glog",
+    "github.com/nmiyake/pkg/dirs",
     "github.com/palantir/pkg/objmatcher",
     "github.com/palantir/pkg/safejson",
     "github.com/palantir/witchcraft-go-error",

--- a/example-apps/producer/producer.go
+++ b/example-apps/producer/producer.go
@@ -30,7 +30,7 @@ func ProduceNumberContext(ctx context.Context) int {
 
 func ProduceNumberNoContext() int {
 	newNum := rand.Int()
-	logger := svc1log.DefaultLogger()
+	logger := svc1log.FromContext(context.Background())
 	logger.Info("ProduceNumberNoContext produced a number", svc1log.SafeParam("newNum", newNum))
 	return newNum
 }

--- a/vendor/github.com/nmiyake/pkg/LICENSE
+++ b/vendor/github.com/nmiyake/pkg/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Nick Miyake
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/nmiyake/pkg/dirs/dirs.go
+++ b/vendor/github.com/nmiyake/pkg/dirs/dirs.go
@@ -1,0 +1,100 @@
+// MIT License
+//
+// Copyright (c) 2016 Nick Miyake
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Package dirs implements utility functions for creating, getting information on and removing directories.
+package dirs
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// SetGoEnvVariables sets the values of the GOPATH and GOROOT environment variables to be the correct values with all
+// symbolic links evaluated. The GOPATH to resolve is determined by using the original value of the GOPATH environment
+// variable, while the GOROOT to resolve is determined using the GoRoot() function.
+func SetGoEnvVariables() error {
+	// set GOPATH environment variable to current value of GOPATH environment variable with symlinks resolved
+	gopath := os.Getenv("GOPATH")
+	if resolvedGoPath, err := filepath.EvalSymlinks(gopath); err == nil {
+		gopath = resolvedGoPath
+	}
+	if err := os.Setenv("GOPATH", gopath); err != nil {
+		return err
+	}
+
+	// set GOROOT environment variable to be current value of Go root determined by GoRoot() with symlinks resolved
+	goroot, err := GoRoot()
+	if err != nil {
+		return err
+	}
+	if resolvedGoRoot, err := filepath.EvalSymlinks(goroot); err == nil {
+		goroot = resolvedGoRoot
+	}
+	if err := os.Setenv("GOROOT", goroot); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GoRoot returns the value for GOROOT for the current system. Similar to runtime.GOROOT(), but if the GOROOT
+// environment variable is not set, falls back on the value provided by the output of running "go env GOROOT" rather
+// than using sys.DefaultGoroot. This approach is more portable in situations where the binary is being run in an
+// environment that is different from the one in which it is compiled.
+func GoRoot() (string, error) {
+	if goroot := os.Getenv("GOROOT"); goroot != "" {
+		return goroot, nil
+	}
+	if output, err := exec.Command("go", "env", "GOROOT").CombinedOutput(); err == nil {
+		return strings.TrimSpace(string(output)), nil
+	}
+	return "", fmt.Errorf("unable to determine GOROOT")
+}
+
+// GetwdEvalSymLinks returns the working directory of the current process using os.GetWd(). Returns the path with all
+// symbolic links resolved (equivalent to 'pwd -P'). Returns an error if os.Getwd or filepath.EvalSymlinks returns an
+// error.
+func GetwdEvalSymLinks() (string, error) {
+	// get wd
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	// resolve any symlinks in path
+	physicalWd, err := filepath.EvalSymlinks(wd)
+	if err != nil {
+		return "", err
+	}
+	return physicalWd, nil
+}
+
+// MustGetwdEvalSymLinks returns the result of GetwdEvalSymLinks. If GetwdEvalSymLinks returns an error, panics.
+func MustGetwdEvalSymLinks() string {
+	physicalWd, err := GetwdEvalSymLinks()
+	if err != nil {
+		panic(fmt.Sprintf("failed to get real path to wd: %v", err))
+	}
+	return physicalWd
+}

--- a/vendor/github.com/nmiyake/pkg/dirs/testdir.go
+++ b/vendor/github.com/nmiyake/pkg/dirs/testdir.go
@@ -1,0 +1,67 @@
+// MIT License
+//
+// Copyright (c) 2016 Nick Miyake
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package dirs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+// TempDir creates a directory using ioutil.TempDir. If the ioutil.TempDir call is successful, returns its result and a
+// function that removes the directory. The returned function is suitable for use in a defer call.
+func TempDir(dir, prefix string) (string, func(), error) {
+	path, err := ioutil.TempDir(dir, prefix)
+	if err != nil {
+		return "", nil, err
+	}
+	return path, RemoveAllFunc(path), nil
+}
+
+// RemoveAllFunc returns a function that calls os.RemoveAll on the specified path and prints any error that is
+// encountered using fmt.Printf. Useful as a defer function to clean up directories created in tests.
+func RemoveAllFunc(path string) func() {
+	return func() {
+		if err := os.RemoveAll(path); err != nil {
+			fmt.Printf("Failed to remove directory %v in defer: %v", path, err)
+		}
+	}
+}
+
+// SetwdWithRestorer sets the working directory to be the specified directory and returns a function that restores the
+// working directory to the value before it was changed. The returned function is suitable for use in a defer call.
+func SetwdWithRestorer(dir string) (func(), error) {
+	origWd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chdir(dir); err != nil {
+		return nil, err
+	}
+	return func() {
+		// restore working directory
+		if err := os.Chdir(origWd); err != nil {
+			fmt.Printf("failed to restore working directory to %s: %v", origWd, err)
+		}
+	}, nil
+}

--- a/vendor/github.com/nmiyake/pkg/godel/config/license.yml
+++ b/vendor/github.com/nmiyake/pkg/godel/config/license.yml
@@ -1,0 +1,22 @@
+header: |
+  // MIT License
+  //
+  // Copyright (c) 2016 Nick Miyake
+  //
+  // Permission is hereby granted, free of charge, to any person obtaining a copy
+  // of this software and associated documentation files (the "Software"), to deal
+  // in the Software without restriction, including without limitation the rights
+  // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  // copies of the Software, and to permit persons to whom the Software is
+  // furnished to do so, subject to the following conditions:
+  //
+  // The above copyright notice and this permission notice shall be included in all
+  // copies or substantial portions of the Software.
+  //
+  // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  // SOFTWARE.

--- a/wlog/auditlog/audit2log/context.go
+++ b/wlog/auditlog/audit2log/context.go
@@ -59,5 +59,5 @@ func loggerFromContext(ctx context.Context) Logger {
 	if logger, ok := ctx.Value(contextKey).(Logger); ok {
 		return logger
 	}
-	return DefaultLogger()
+	return defaultLoggerCreator()
 }

--- a/wlog/context_default_test.go
+++ b/wlog/context_default_test.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wlog_test
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/nmiyake/pkg/dirs"
+	"github.com/palantir/witchcraft-go-logging/conjure/sls/spec/logging"
+	"github.com/palantir/witchcraft-go-logging/wlog"
+	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/audit2log"
+	"github.com/palantir/witchcraft-go-logging/wlog/evtlog/evt2log"
+	"github.com/palantir/witchcraft-go-logging/wlog/metriclog/metric1log"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests the behavior of logging output using the logger retrieved from a context.Context when no logger was set on the
+// context. Each logger type has its own functions for retrieving the logger from the context, so this test is defined
+// as a set of tests run on for each logger that supports being stored in and retrieved from a context.
+//
+// There are 3 cases that are tested:
+//   * No default logger is set for the logger type and no global logger provider is set
+//   * No default logger is set for the logger type and a JSON-writing global logger provider is set
+//   * A no-op default logger is set for the logger type
+//
+// See the comments on the test cases in testFromContextFromEmptyContextForSingleLogger for more details on the tests
+// and the expected behavior that is tested.
+//
+// Note that, because these tests are testing behavior based on global state, they should not be run in parallel.
+func TestOutputFromContextEmptyContext(t *testing.T) {
+	tmpDir, cleanup, err := dirs.TempDir("", "")
+	require.NoError(t, err)
+	defer cleanup()
+
+	// set os.Stderr to be the temporary file and defer restoration
+	prevStderr := os.Stderr
+	defer func() {
+		os.Stderr = prevStderr
+	}()
+
+	for _, tc := range []loggerTestCase{
+		{
+			loggerPkg: "audit2log",
+			performLogging: func() {
+				logger := audit2log.FromContext(context.Background())
+				logger.Audit("TEST_EVT", audit2log.AuditResultSuccess)
+			},
+			validateJSON: func(bytes []byte) {
+				var logEntry logging.AuditLogV2
+				require.NoError(t, json.Unmarshal([]byte(bytes), &logEntry))
+				assert.Equal(t, "TEST_EVT", logEntry.Name)
+			},
+			setEmptyLoggerCreator: func() {
+				// set the default logger creator
+				audit2log.SetDefaultLoggerCreator(func() audit2log.Logger {
+					// technically, a truly no-op writer would implement the logger interface and do nothing, but it is
+					// easier to just return a new logger that writes to a no-op writer.
+					return audit2log.New(ioutil.Discard)
+				})
+			},
+		},
+		{
+			loggerPkg: "evt2log",
+			performLogging: func() {
+				logger := evt2log.FromContext(context.Background())
+				logger.Event("TEST_EVT")
+			},
+			validateJSON: func(bytes []byte) {
+				var logEntry logging.EventLogV2
+				require.NoError(t, json.Unmarshal([]byte(bytes), &logEntry))
+				assert.Equal(t, "TEST_EVT", logEntry.EventName)
+			},
+			setEmptyLoggerCreator: func() {
+				// set the default logger creator
+				evt2log.SetDefaultLoggerCreator(func() evt2log.Logger {
+					// technically, a truly no-op writer would implement the logger interface and do nothing, but it is
+					// easier to just return a new logger that writes to a no-op writer.
+					return evt2log.New(ioutil.Discard)
+				})
+			},
+		},
+		{
+			loggerPkg: "metric1log",
+			performLogging: func() {
+				logger := metric1log.FromContext(context.Background())
+				logger.Metric("com.palantir.metric", "gauge")
+			},
+			validateJSON: func(bytes []byte) {
+				var logEntry logging.MetricLogV1
+				require.NoError(t, json.Unmarshal([]byte(bytes), &logEntry))
+				assert.Equal(t, "com.palantir.metric", logEntry.MetricName)
+				assert.Equal(t, "gauge", logEntry.MetricType)
+			},
+			setEmptyLoggerCreator: func() {
+				// set the default logger creator
+				metric1log.SetDefaultLoggerCreator(func() metric1log.Logger {
+					// technically, a truly no-op writer would implement the logger interface and do nothing, but it is
+					// easier to just return a new logger that writes to a no-op writer.
+					return metric1log.New(ioutil.Discard)
+				})
+			},
+		},
+		{
+			loggerPkg: "svc1log",
+			performLogging: func() {
+				logger := svc1log.FromContext(context.Background())
+				logger.Info("Test message")
+			},
+			validateJSON: func(bytes []byte) {
+				var logEntry logging.ServiceLogV1
+				require.NoError(t, json.Unmarshal([]byte(bytes), &logEntry))
+				assert.Equal(t, "Test message", logEntry.Message)
+				assert.Equal(t, logging.LogLevel("INFO"), logEntry.Level)
+			},
+			setEmptyLoggerCreator: func() {
+				// set the default logger creator
+				svc1log.SetDefaultLoggerCreator(func() svc1log.Logger {
+					// technically, a truly no-op writer would implement the logger interface and do nothing, but it is
+					// easier to just return a new logger that writes to a no-op writer.
+					return svc1log.New(ioutil.Discard, wlog.InfoLevel)
+				})
+			},
+		},
+	} {
+		t.Run(tc.loggerPkg, func(t *testing.T) {
+			testFromContextFromEmptyContextForSingleLogger(t, tmpDir, tc)
+		})
+	}
+}
+
+type loggerTestCase struct {
+	loggerPkg             string
+	performLogging        func()
+	validateJSON          func([]byte)
+	setEmptyLoggerCreator func()
+}
+
+func testFromContextFromEmptyContextForSingleLogger(t *testing.T, tmpDir string, loggerTestCaseInfo loggerTestCase) {
+	for _, tc := range []struct {
+		name   string
+		before func(loggerTestCase)
+		verify func(loggerTestCase, []byte)
+	}{
+		// Because the context has no logger set on it, the defaultLoggerCreator is used. The defaultLoggerCreator has
+		// not been set, so the default implementation writes a warning to os.Stderr followed by the logger output for
+		// a logger created by using wlog.DefaultLoggerProvider. Because wlog.DefaultLoggerProvider has not been set,
+		// the logger created by that function outputs a warning stating that the global logger should be set. As a
+		// result, the over-all logger output to os.Stderr is:
+		// "[WARNING] <logger not set in context>: [WARNING] <global logger provider not set>"
+		{
+			name: "Context with no logger set and no logger provider set returns default stderr warning logger that uses warn-once logger",
+			verify: func(loggerTestCaseInfo loggerTestCase, bytes []byte) {
+				logOutput := string(bytes)
+
+				firstPortionRegexp := regexp.MustCompile(
+					regexp.QuoteMeta(`[WARNING] github.com/palantir/witchcraft-go-logging/wlog_test.TestOutputFromContextEmptyContext`) + ".+" + regexp.QuoteMeta(`/github.com/palantir/witchcraft-go-logging/wlog/context_default_test.go:`) + "[0-9]+" + regexp.QuoteMeta(`]: usage of `+loggerTestCaseInfo.loggerPkg+`.Logger from FromContext that did not have that logger set: `))
+				loc := firstPortionRegexp.FindStringIndex(logOutput)
+				require.NotNil(t, loc, "Unexpected log output: %s", logOutput)
+
+				got := strings.TrimSuffix(logOutput[loc[1]:], "\n")
+				assert.Equal(t, `[WARNING] Logging operation that uses the default logger provider was performed without specifying a logger provider implementation. To see logger output, set the global logger provider implementation using wlog.SetDefaultLoggerProvider or by importing an implementation. This warning can be disabled by setting the global logger provider to be the noop logger provider using wlog.SetDefaultLoggerProvider(wlog.NewNoopLoggerProvider()).`, got)
+			},
+		},
+		// Because the context has no logger set on it, the defaultLoggerCreator is used. The defaultLoggerCreator has
+		// not been set, so the default implementation writes a warning to os.Stderr followed by the logger output for
+		// a logger created by using wlog.DefaultLoggerProvider. wlog.DefaultLoggerProvider has been set to
+		// wlog.NewJSONMarshalLoggerProvider(), so the over-all logger output to os.Stderr is:
+		// "[WARNING] <logger not set in context>: <JSON logger output>"
+		{
+			name: "Context with no logger set and no logger provider set returns default stderr warning logger that uses set logger provider",
+			before: func(loggerTestCaseInfo loggerTestCase) {
+				// set the default logger provider to be the JSON marshal logger provider
+				wlog.SetDefaultLoggerProvider(wlog.NewJSONMarshalLoggerProvider())
+			},
+			verify: func(loggerTestCaseInfo loggerTestCase, bytes []byte) {
+				logOutput := string(bytes)
+
+				firstPortionRegexp := regexp.MustCompile(
+					regexp.QuoteMeta(`[WARNING] github.com/palantir/witchcraft-go-logging/wlog_test.TestOutputFromContextEmptyContext`) + ".+" + regexp.QuoteMeta(`/github.com/palantir/witchcraft-go-logging/wlog/context_default_test.go:`) + "[0-9]+" + regexp.QuoteMeta(`]: usage of `+loggerTestCaseInfo.loggerPkg+`.Logger from FromContext that did not have that logger set: `))
+				loc := firstPortionRegexp.FindStringIndex(logOutput)
+				require.NotNil(t, loc, "Unexpected log output: %s", logOutput)
+
+				loggerTestCaseInfo.validateJSON([]byte(logOutput[loc[1]:]))
+			},
+		},
+		// Because the context has no logger set on it, the defaultLoggerCreator is used. The defaultLoggerCreator has
+		// been set to be a no-op one, so the result is that nothing is logged.
+		{
+			name: "Context with no logger set and no logger provider set returns default stderr warning logger that uses set logger provider",
+			before: func(loggerTestCaseInfo loggerTestCase) {
+				loggerTestCaseInfo.setEmptyLoggerCreator()
+			},
+			verify: func(loggerTestCaseInfo loggerTestCase, bytes []byte) {
+				assert.Equal(t, "", string(bytes))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// store and restore global default logger provider so that tests can assume that default one is set
+			originalProvider := wlog.DefaultLoggerProvider()
+			defer func() {
+				wlog.SetDefaultLoggerProvider(originalProvider)
+			}()
+
+			f, err := ioutil.TempFile(tmpDir, "")
+			require.NoError(t, err)
+			defer func() {
+				_ = f.Close()
+			}()
+			os.Stderr = f
+
+			if tc.before != nil {
+				tc.before(loggerTestCaseInfo)
+			}
+
+			// get logger from context and perform logging
+			loggerTestCaseInfo.performLogging()
+
+			err = f.Close()
+			require.NoError(t, err)
+
+			bytes, err := ioutil.ReadFile(f.Name())
+			require.NoError(t, err)
+
+			// verify logger output
+			tc.verify(loggerTestCaseInfo, bytes)
+		})
+	}
+}

--- a/wlog/evtlog/evt2log/context.go
+++ b/wlog/evtlog/evt2log/context.go
@@ -59,5 +59,5 @@ func loggerFromContext(ctx context.Context) Logger {
 	if logger, ok := ctx.Value(contextKey).(Logger); ok {
 		return logger
 	}
-	return DefaultLogger()
+	return defaultLoggerCreator()
 }

--- a/wlog/evtlog/evt2log/default.go
+++ b/wlog/evtlog/evt2log/default.go
@@ -15,9 +15,39 @@
 package evt2log
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"os"
+
+	"github.com/palantir/witchcraft-go-logging/wlog"
+	"github.com/palantir/witchcraft-go-logging/wlog/internal"
 )
 
-func DefaultLogger() Logger {
-	return New(os.Stdout)
+func SetDefaultLoggerCreator(creator func() Logger) {
+	defaultLoggerCreator = creator
+}
+
+var defaultLoggerCreator = func() Logger {
+	return &warnLogger{
+		w: os.Stderr,
+		// store the DefaultLoggerProvider at creation-time so that the output of this logger will be consistent
+		// throughout its lifetime (if the default logger provider is changed after a specific warnLogger is created,
+		// that should not change the creator used for that warnLogger).
+		creator: wlog.DefaultLoggerProvider().NewLogger,
+	}
+}
+
+// warnLogger is a logger that writes a warning to the provided io.Writer whenever its logging function is invoked. When
+// the logging function is invoked, a new logger is created using the wlog.LoggerCreator and a warning and the output of
+// the created logger are written to the io.Writer.
+type warnLogger struct {
+	w       io.Writer
+	creator wlog.LoggerCreator
+}
+
+func (l *warnLogger) Event(name string, params ...Param) {
+	buf := &bytes.Buffer{}
+	NewFromCreator(buf, l.creator).Event(name, params...)
+	_, _ = fmt.Fprintln(l.w, wloginternal.WarnLoggerOutput("evt2log", buf.String(), 2))
 }

--- a/wlog/internal/default_logger.go
+++ b/wlog/internal/default_logger.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wloginternal
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// WarnLoggerOutput returns the logger output for a default warning logger for a given logger type. The output includes
+// the location at which the call was made, with the "skip" parameter determining how far back in the call stack to go
+// for the location (for example, skip=0 specifies the line in this function, skip=1 specifies the line that called this
+// function, etc.).
+//
+// This function is defined in an internal package because each logger type needs to define its own warning logger type
+// but the format/content of the output should be consistent across them.
+func WarnLoggerOutput(loggerType, output string, skip int) string {
+	pc, fn, line, _ := runtime.Caller(skip)
+	return fmt.Sprintf("[WARNING] %s[%s:%d]: usage of %s.Logger from FromContext that did not have that logger set: %s", runtime.FuncForPC(pc).Name(), fn, line, loggerType, strings.TrimSuffix(output, "\n"))
+}

--- a/wlog/metriclog/metric1log/context.go
+++ b/wlog/metriclog/metric1log/context.go
@@ -54,5 +54,5 @@ func loggerFromContext(ctx context.Context) Logger {
 	if logger, ok := ctx.Value(contextKey).(Logger); ok {
 		return logger
 	}
-	return DefaultLogger()
+	return defaultLoggerCreator()
 }

--- a/wlog/metriclog/metric1log/default.go
+++ b/wlog/metriclog/metric1log/default.go
@@ -15,9 +15,39 @@
 package metric1log
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"os"
+
+	"github.com/palantir/witchcraft-go-logging/wlog"
+	"github.com/palantir/witchcraft-go-logging/wlog/internal"
 )
 
-func DefaultLogger() Logger {
-	return New(os.Stdout)
+func SetDefaultLoggerCreator(creator func() Logger) {
+	defaultLoggerCreator = creator
+}
+
+var defaultLoggerCreator = func() Logger {
+	return &warnLogger{
+		w: os.Stderr,
+		// store the DefaultLoggerProvider at creation-time so that the output of this logger will be consistent
+		// throughout its lifetime (if the default logger provider is changed after a specific warnLogger is created,
+		// that should not change the creator used for that warnLogger).
+		creator: wlog.DefaultLoggerProvider().NewLogger,
+	}
+}
+
+// warnLogger is a logger that writes a warning to the provided io.Writer whenever its logging function is invoked. When
+// the logging function is invoked, a new logger is created using the wlog.LoggerCreator and a warning and the output of
+// the created logger are written to the io.Writer.
+type warnLogger struct {
+	w       io.Writer
+	creator wlog.LoggerCreator
+}
+
+func (l *warnLogger) Metric(name, typ string, params ...Param) {
+	buf := &bytes.Buffer{}
+	NewFromCreator(buf, l.creator).Metric(name, typ, params...)
+	_, _ = fmt.Fprintln(l.w, wloginternal.WarnLoggerOutput("metric1log", buf.String(), 2))
 }

--- a/wlog/svclog/svc1log/context.go
+++ b/wlog/svclog/svc1log/context.go
@@ -89,5 +89,5 @@ func loggerFromContext(ctx context.Context) Logger {
 	if logger, ok := ctx.Value(contextKey).(Logger); ok {
 		return logger
 	}
-	return DefaultLogger()
+	return defaultLoggerCreator()
 }

--- a/wlog/svclog/svc1log/default.go
+++ b/wlog/svclog/svc1log/default.go
@@ -15,11 +15,93 @@
 package svc1log
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"os"
 
 	"github.com/palantir/witchcraft-go-logging/wlog"
+	"github.com/palantir/witchcraft-go-logging/wlog/internal"
 )
 
-func DefaultLogger() Logger {
-	return New(os.Stdout, wlog.InfoLevel)
+func SetDefaultLoggerCreator(creator func() Logger) {
+	defaultLoggerCreator = creator
+}
+
+var defaultLoggerCreator = func() Logger {
+	return &warnLogger{
+		w: os.Stderr,
+		// store the DefaultLoggerProvider at creation-time so that the output of this logger will be consistent
+		// throughout its lifetime (if the default logger provider is changed after a specific warnLogger is created,
+		// that should not change the creator used for that warnLogger).
+		creator: wlog.DefaultLoggerProvider().NewLeveledLogger,
+		level:   wlog.InfoLevel,
+	}
+}
+
+// warnLogger is a logger that writes a warning to the provided io.Writer whenever its logging function is invoked. When
+// the logging function is invoked, a new logger is created using the wlog.LoggerCreator and a warning and the output of
+// the created logger are written to the io.Writer.
+type warnLogger struct {
+	w       io.Writer
+	creator wlog.LeveledLoggerCreator
+	level   wlog.LogLevel
+}
+
+func (l *warnLogger) Debug(msg string, params ...Param) {
+	switch l.level {
+	case wlog.DebugLevel:
+	default:
+		return
+	}
+
+	l.log(func(logger Logger) {
+		logger.Debug(msg, params...)
+	})
+}
+
+func (l *warnLogger) Info(msg string, params ...Param) {
+	switch l.level {
+	case wlog.DebugLevel, wlog.InfoLevel:
+	default:
+		return
+	}
+
+	l.log(func(logger Logger) {
+		logger.Info(msg, params...)
+	})
+}
+
+func (l *warnLogger) Warn(msg string, params ...Param) {
+	switch l.level {
+	case wlog.DebugLevel, wlog.InfoLevel, wlog.WarnLevel:
+	default:
+		return
+	}
+
+	l.log(func(logger Logger) {
+		logger.Warn(msg, params...)
+	})
+}
+
+func (l *warnLogger) Error(msg string, params ...Param) {
+	switch l.level {
+	case wlog.DebugLevel, wlog.InfoLevel, wlog.WarnLevel, wlog.ErrorLevel:
+	default:
+		return
+	}
+
+	l.log(func(logger Logger) {
+		logger.Error(msg, params...)
+	})
+}
+
+func (l *warnLogger) SetLevel(level wlog.LogLevel) {
+	l.level = level
+}
+
+func (l *warnLogger) log(logFn func(logger Logger)) {
+	buf := &bytes.Buffer{}
+	logFn(NewFromCreator(buf, l.level, l.creator))
+	_, _ = fmt.Fprintln(l.w, wloginternal.WarnLoggerOutput("svc1log", buf.String(), 4))
 }


### PR DESCRIPTION
Previously, if "FromContext" was used to extract a logger from a
context on which no logger was set, the function would return a
default logger that wrote to STDOUT.

This commit changes the behavior such that it is possible to
specify the logger that is returned in this case and modifies the
default behavior to return a logger that logs a warning to STDERR
stating that the logger being used was retrieved from a context
that does not contain a logger.

Fixes #4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/11)
<!-- Reviewable:end -->
