### PR TITLE
Remove unused tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Active TODOs
 * Add section on usage to README
 * Improve testing loggers that produce non-JSON output (glog)
 * Port over more tests for audit logs
-* Remove tests that update loggers
 
 License
 -------

--- a/wlog/auditlog/audit2log/audit2logtests/tests.go
+++ b/wlog/auditlog/audit2log/audit2logtests/tests.go
@@ -92,7 +92,6 @@ func TestCases() []TestCase {
 
 func JSONTestSuite(t *testing.T, loggerProvider func(w io.Writer) audit2log.Logger) {
 	jsonOutputTests(t, loggerProvider)
-	//jsonLoggerUpdateTest(t, loggerProvider)
 }
 
 func jsonOutputTests(t *testing.T, loggerProvider func(w io.Writer) audit2log.Logger) {
@@ -122,42 +121,3 @@ func jsonOutputTests(t *testing.T, loggerProvider func(w io.Writer) audit2log.Lo
 		})
 	}
 }
-
-//func jsonLoggerUpdateTest(t *testing.T, loggerProvider func(params wlog.LoggerParams, origin string) svc1log.Logger) {
-//	t.Run("update JSON logger", func(t *testing.T) {
-//		currCase := TestCases()[0]
-//
-//		buf := bytes.Buffer{}
-//		logger := loggerProvider(wlog.LoggerParams{
-//			Level:  wlog.ErrorLevel,
-//			Output: &buf,
-//		}, currCase.Origin)
-//
-//		// log at info level
-//		logger.Info(currCase.Message, currCase.LogParams...)
-//
-//		// output should be empty
-//		assert.Equal(t, "", buf.String())
-//
-//		// update configuration to log at info level
-//		updatable, ok := logger.(wlog.UpdatableLogger)
-//		require.True(t, ok, "logger does not support updating")
-//
-//		updated := updatable.UpdateLogger(wlog.LoggerParams{
-//			Level:  wlog.InfoLevel,
-//			Output: &buf,
-//		})
-//		assert.True(t, updated)
-//
-//		// log at info level
-//		logger.Info(currCase.Message, currCase.LogParams...)
-//
-//		// output should exist and match
-//		gotServiceLog := map[string]interface{}{}
-//		logEntry := buf.Bytes()
-//		err := safejson.Unmarshal(logEntry, &gotServiceLog)
-//		require.NoError(t, err, "Service log line is not a valid map: %v", string(logEntry))
-//
-//		assert.NoError(t, currCase.JSONMatcher.Matches(gotServiceLog), "No match")
-//	})
-//}

--- a/wlog/diaglog/diag1log/diag1logtests/tests.go
+++ b/wlog/diaglog/diag1log/diag1logtests/tests.go
@@ -147,7 +147,6 @@ func stringVal(in string) *string {
 
 func JSONTestSuite(t *testing.T, loggerProvider func(w io.Writer) diag1log.Logger) {
 	jsonOutputTests(t, loggerProvider)
-	//jsonLoggerUpdateTest(t, loggerProvider)
 }
 
 func jsonOutputTests(t *testing.T, loggerProvider func(w io.Writer) diag1log.Logger) {
@@ -171,42 +170,3 @@ func jsonOutputTests(t *testing.T, loggerProvider func(w io.Writer) diag1log.Log
 		})
 	}
 }
-
-//func jsonLoggerUpdateTest(t *testing.T, loggerProvider func(params wlog.LoggerParams, origin string) svc1log.Logger) {
-//	t.Run("update JSON logger", func(t *testing.T) {
-//		currCase := TestCases()[0]
-//
-//		buf := bytes.Buffer{}
-//		logger := loggerProvider(wlog.LoggerParams{
-//			Level:  wlog.ErrorLevel,
-//			Output: &buf,
-//		}, currCase.Origin)
-//
-//		// log at info level
-//		logger.Info(currCase.Message, currCase.LogParams...)
-//
-//		// output should be empty
-//		assert.Equal(t, "", buf.String())
-//
-//		// update configuration to log at info level
-//		updatable, ok := logger.(wlog.UpdatableLogger)
-//		require.True(t, ok, "logger does not support updating")
-//
-//		updated := updatable.UpdateLogger(wlog.LoggerParams{
-//			Level:  wlog.InfoLevel,
-//			Output: &buf,
-//		})
-//		assert.True(t, updated)
-//
-//		// log at info level
-//		logger.Info(currCase.Message, currCase.LogParams...)
-//
-//		// output should exist and match
-//		gotServiceLog := map[string]interface{}{}
-//		logEntry := buf.Bytes()
-//		err := safejson.Unmarshal(logEntry, &gotServiceLog)
-//		require.NoError(t, err, "Service log line is not a valid map: %v", string(logEntry))
-//
-//		assert.NoError(t, currCase.JSONMatcher.Matches(gotServiceLog), "No match")
-//	})
-//}

--- a/wlog/evtlog/evt2log/evt2logtests/tests.go
+++ b/wlog/evtlog/evt2log/evt2logtests/tests.go
@@ -85,7 +85,6 @@ func TestCases() []TestCase {
 
 func JSONTestSuite(t *testing.T, loggerProvider func(w io.Writer) evt2log.Logger) {
 	jsonOutputTests(t, loggerProvider)
-	//jsonLoggerUpdateTest(t, loggerProvider)
 }
 
 func jsonOutputTests(t *testing.T, loggerProvider func(w io.Writer) evt2log.Logger) {
@@ -105,42 +104,3 @@ func jsonOutputTests(t *testing.T, loggerProvider func(w io.Writer) evt2log.Logg
 		})
 	}
 }
-
-//func jsonLoggerUpdateTest(t *testing.T, loggerProvider func(params wlog.LoggerParams, origin string) svc1log.Logger) {
-//	t.Run("update JSON logger", func(t *testing.T) {
-//		currCase := TestCases()[0]
-//
-//		buf := bytes.Buffer{}
-//		logger := loggerProvider(wlog.LoggerParams{
-//			Level:  wlog.ErrorLevel,
-//			Output: &buf,
-//		}, currCase.Origin)
-//
-//		// log at info level
-//		logger.Info(currCase.Message, currCase.LogParams...)
-//
-//		// output should be empty
-//		assert.Equal(t, "", buf.String())
-//
-//		// update configuration to log at info level
-//		updatable, ok := logger.(wlog.UpdatableLogger)
-//		require.True(t, ok, "logger does not support updating")
-//
-//		updated := updatable.UpdateLogger(wlog.LoggerParams{
-//			Level:  wlog.InfoLevel,
-//			Output: &buf,
-//		})
-//		assert.True(t, updated)
-//
-//		// log at info level
-//		logger.Info(currCase.Message, currCase.LogParams...)
-//
-//		// output should exist and match
-//		gotServiceLog := map[string]interface{}{}
-//		logEntry := buf.Bytes()
-//		err := safejson.Unmarshal(logEntry, &gotServiceLog)
-//		require.NoError(t, err, "Service log line is not a valid map: %v", string(logEntry))
-//
-//		assert.NoError(t, currCase.JSONMatcher.Matches(gotServiceLog), "No match")
-//	})
-//}

--- a/wlog/metriclog/metric1log/metric1logtests/tests.go
+++ b/wlog/metriclog/metric1log/metric1logtests/tests.go
@@ -105,7 +105,6 @@ func TestCases() []TestCase {
 
 func JSONTestSuite(t *testing.T, loggerProvider func(w io.Writer) metric1log.Logger) {
 	jsonOutputTests(t, loggerProvider)
-	//jsonLoggerUpdateTest(t, loggerProvider)
 }
 
 func jsonOutputTests(t *testing.T, loggerProvider func(w io.Writer) metric1log.Logger) {
@@ -125,42 +124,3 @@ func jsonOutputTests(t *testing.T, loggerProvider func(w io.Writer) metric1log.L
 		})
 	}
 }
-
-//func jsonLoggerUpdateTest(t *testing.T, loggerProvider func(params wlog.LoggerParams, origin string) svc1log.Logger) {
-//	t.Run("update JSON logger", func(t *testing.T) {
-//		currCase := TestCases()[0]
-//
-//		buf := bytes.Buffer{}
-//		logger := loggerProvider(wlog.LoggerParams{
-//			Level:  wlog.ErrorLevel,
-//			Output: &buf,
-//		}, currCase.Origin)
-//
-//		// log at info level
-//		logger.Info(currCase.Message, currCase.LogParams...)
-//
-//		// output should be empty
-//		assert.Equal(t, "", buf.String())
-//
-//		// update configuration to log at info level
-//		updatable, ok := logger.(wlog.UpdatableLogger)
-//		require.True(t, ok, "logger does not support updating")
-//
-//		updated := updatable.UpdateLogger(wlog.LoggerParams{
-//			Level:  wlog.InfoLevel,
-//			Output: &buf,
-//		})
-//		assert.True(t, updated)
-//
-//		// log at info level
-//		logger.Info(currCase.Message, currCase.LogParams...)
-//
-//		// output should exist and match
-//		gotServiceLog := map[string]interface{}{}
-//		logEntry := buf.Bytes()
-//		err := safejson.Unmarshal(logEntry, &gotServiceLog)
-//		require.NoError(t, err, "Service log line is not a valid map: %v", string(logEntry))
-//
-//		assert.NoError(t, currCase.JSONMatcher.Matches(gotServiceLog), "No match")
-//	})
-//}

--- a/wlog/reqlog/req2log/req2logtests/tests.go
+++ b/wlog/reqlog/req2log/req2logtests/tests.go
@@ -199,7 +199,6 @@ func TestCases() []TestCase {
 
 func JSONTestSuite(t *testing.T, loggerProvider func(w io.Writer, params ...req2log.LoggerCreatorParam) req2log.Logger) {
 	jsonOutputTests(t, loggerProvider)
-	//jsonLoggerUpdateTest(t, loggerProvider)
 }
 
 func jsonOutputTests(t *testing.T, loggerProvider func(w io.Writer, params ...req2log.LoggerCreatorParam) req2log.Logger) {
@@ -264,42 +263,3 @@ func GenerateRequest(requestHeaders map[string]string, extraQueryParams []string
 	}
 	return req
 }
-
-//func jsonLoggerUpdateTest(t *testing.T, loggerProvider func(params wlog.LoggerParams, origin string) svc1log.Logger) {
-//	t.Run("update JSON logger", func(t *testing.T) {
-//		currCase := TestCases()[0]
-//
-//		buf := bytes.Buffer{}
-//		logger := loggerProvider(wlog.LoggerParams{
-//			Level:  wlog.ErrorLevel,
-//			Output: &buf,
-//		}, currCase.Origin)
-//
-//		// log at info level
-//		logger.Info(currCase.Message, currCase.LogParams...)
-//
-//		// output should be empty
-//		assert.Equal(t, "", buf.String())
-//
-//		// update configuration to log at info level
-//		updatable, ok := logger.(wlog.UpdatableLogger)
-//		require.True(t, ok, "logger does not support updating")
-//
-//		updated := updatable.UpdateLogger(wlog.LoggerParams{
-//			Level:  wlog.InfoLevel,
-//			Output: &buf,
-//		})
-//		assert.True(t, updated)
-//
-//		// log at info level
-//		logger.Info(currCase.Message, currCase.LogParams...)
-//
-//		// output should exist and match
-//		gotServiceLog := map[string]interface{}{}
-//		logEntry := buf.Bytes()
-//		err := safejson.Unmarshal(logEntry, &gotServiceLog)
-//		require.NoError(t, err, "Service log line is not a valid map: %v", string(logEntry))
-//
-//		assert.NoError(t, currCase.JSONMatcher.Matches(gotServiceLog), "No match")
-//	})
-//}


### PR DESCRIPTION
Relevant interface previously changed to no longer support updates,
so remove outdated update tests that were commented out.