### PR TITLE
Improve resiliency of wlog.LogLevel values

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -183,6 +183,7 @@
     "github.com/stretchr/testify/require",
     "go.uber.org/zap",
     "go.uber.org/zap/zapcore",
+    "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/wlog-zap/internal/provider.go
+++ b/wlog-zap/internal/provider.go
@@ -73,7 +73,7 @@ func toZapLevel(lvl wlog.LogLevel) zapcore.Level {
 	switch lvl {
 	case wlog.DebugLevel:
 		return zapcore.DebugLevel
-	case wlog.InfoLevel:
+	case wlog.LogLevel(""), wlog.InfoLevel:
 		return zapcore.InfoLevel
 	case wlog.WarnLevel:
 		return zapcore.WarnLevel

--- a/wlog-zerolog/internal/provider.go
+++ b/wlog-zerolog/internal/provider.go
@@ -48,7 +48,7 @@ func toZeroLevel(lvl wlog.LogLevel) zerolog.Level {
 	switch lvl {
 	case wlog.DebugLevel:
 		return zerolog.DebugLevel
-	case wlog.InfoLevel:
+	case wlog.LogLevel(""), wlog.InfoLevel:
 		return zerolog.InfoLevel
 	case wlog.WarnLevel:
 		return zerolog.WarnLevel

--- a/wlog/levels.go
+++ b/wlog/levels.go
@@ -14,6 +14,11 @@
 
 package wlog
 
+import (
+	"fmt"
+	"strings"
+)
+
 type LogLevel string
 
 const (
@@ -23,3 +28,25 @@ const (
 	ErrorLevel LogLevel = "error"
 	FatalLevel LogLevel = "fatal"
 )
+
+func (l *LogLevel) UnmarshalText(b []byte) error {
+	switch strings.ToLower(string(b)) {
+	case string(DebugLevel):
+		*l = DebugLevel
+		return nil
+	case "", string(InfoLevel):
+		*l = InfoLevel
+		return nil
+	case string(WarnLevel):
+		*l = WarnLevel
+		return nil
+	case string(ErrorLevel):
+		*l = ErrorLevel
+		return nil
+	case string(FatalLevel):
+		*l = FatalLevel
+		return nil
+	default:
+		return fmt.Errorf("invalid log level: %q", string(b))
+	}
+}

--- a/wlog/levels_test.go
+++ b/wlog/levels_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wlog_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/palantir/witchcraft-go-logging/wlog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestUnmarshalJSON(t *testing.T) {
+	for i, tc := range []struct {
+		in   string
+		want wlog.LogLevel
+	}{
+		{`"debug"`, wlog.DebugLevel},
+		{`"DEBUG"`, wlog.DebugLevel},
+		{`"DeBuG"`, wlog.DebugLevel},
+		{`""`, wlog.InfoLevel},
+	} {
+		var got wlog.LogLevel
+		err := json.Unmarshal([]byte(tc.in), &got)
+		require.NoError(t, err, "Case %d", i)
+		assert.Equal(t, tc.want, got, "Case %d", i)
+	}
+}
+
+func TestUnmarshalJSONError(t *testing.T) {
+	for i, tc := range []struct {
+		in        string
+		wantError string
+	}{
+		{`"Critical"`, `invalid log level: "Critical"`},
+	} {
+		var got wlog.LogLevel
+		err := json.Unmarshal([]byte(tc.in), &got)
+		assert.EqualError(t, err, tc.wantError, "Case %d", i)
+	}
+}
+
+func TestUnmarshalYAML(t *testing.T) {
+	for i, tc := range []struct {
+		in   string
+		want wlog.LogLevel
+	}{
+		{`debug`, wlog.DebugLevel},
+		{`DEBUG`, wlog.DebugLevel},
+		{`DeBuG`, wlog.DebugLevel},
+		{`""`, wlog.InfoLevel},
+	} {
+		var got wlog.LogLevel
+		err := yaml.Unmarshal([]byte(tc.in), &got)
+		require.NoError(t, err, "Case %d", i)
+		assert.Equal(t, tc.want, got, "Case %d", i)
+	}
+}
+
+func TestUnmarshalYAMLError(t *testing.T) {
+	for i, tc := range []struct {
+		in        string
+		wantError string
+	}{
+		{`"Critical"`, `invalid log level: "Critical"`},
+	} {
+		var got wlog.LogLevel
+		err := yaml.Unmarshal([]byte(tc.in), &got)
+		assert.EqualError(t, err, tc.wantError, "Case %d", i)
+	}
+}


### PR DESCRIPTION
* Add UnmarshalText function to standardize casing, convert blank
  to info and error on invalid values
* Update logger providers to interpret empty LogLevel values as INFO

Fixes #37

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/38)
<!-- Reviewable:end -->
