### PR TITLE
Add wapp.RunWithRecoveryLogging which does not return errors

### DIFF
--- a/wlog/wapp/fatal.go
+++ b/wlog/wapp/fatal.go
@@ -24,8 +24,35 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
+// RunWithRecovery wraps a callback, logging any panics recovered as errors.
+// Useful as a "catch all" for applications so that they can log fatal events, perhaps before exiting.
+func RunWithRecovery(ctx context.Context, runFn func(ctx context.Context)) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		stacktrace := diag1log.ThreadDumpV1FromGoroutines(debug.Stack())
+		if err, ok := r.(error); ok {
+			svc1log.FromContext(ctx).Error("panic recovered",
+				svc1log.SafeParam("stacktrace", stacktrace),
+				svc1log.Stacktrace(err))
+		} else {
+			svc1log.FromContext(ctx).Error("panic recovered",
+				svc1log.SafeParam("stacktrace", stacktrace),
+				svc1log.UnsafeParam("recovered", r))
+		}
+		if evtlog := evt2log.FromContext(ctx); evtlog != nil {
+			evtlog.Event("wapp.panic_recovered",
+				evt2log.Value("stacktrace", stacktrace),
+				evt2log.UnsafeParam("recovered", r))
+		}
+	}()
+	runFn(ctx)
+}
+
 // RunWithFatalLogging wraps a callback, logging errors and panics it returns.
-// Useful as a "catch all" for applications so that they can sls log fatal events, perhaps before exiting.
+// Useful as a "catch all" for applications so that they can log fatal events, perhaps before exiting.
 func RunWithFatalLogging(ctx context.Context, runFn func(ctx context.Context) error) (retErr error) {
 	defer func() {
 		r := recover()

--- a/wlog/wapp/fatal_test.go
+++ b/wlog/wapp/fatal_test.go
@@ -31,10 +31,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRunWithRecovery_Panic(t *testing.T) {
+func TestRunWithRecoveryLogging_Panic(t *testing.T) {
 	buf := &bytes.Buffer{}
 	ctx := getContextWithLogger(context.Background(), buf)
-	wapp.RunWithRecovery(ctx, func(ctx context.Context) {
+	wapp.RunWithRecoveryLogging(ctx, func(ctx context.Context) {
 		panic("foo")
 	})
 	var msg logging.ServiceLogV1

--- a/wlog/wapp/fatal_test.go
+++ b/wlog/wapp/fatal_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package wapp
+package wapp_test
 
 import (
 	"bytes"
@@ -21,17 +21,33 @@ import (
 	"io"
 	"testing"
 
+	"github.com/palantir/pkg/safejson"
 	"github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/witchcraft-go-logging/conjure/witchcraft/api/logging"
 	"github.com/palantir/witchcraft-go-logging/wlog"
 	_ "github.com/palantir/witchcraft-go-logging/wlog-zap"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/palantir/witchcraft-go-logging/wlog/wapp"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestRunWithRecovery_Panic(t *testing.T) {
+	buf := &bytes.Buffer{}
+	ctx := getContextWithLogger(context.Background(), buf)
+	wapp.RunWithRecovery(ctx, func(ctx context.Context) {
+		panic("foo")
+	})
+	var msg logging.ServiceLogV1
+	err := safejson.Unmarshal(buf.Bytes(), &msg)
+	assert.NoError(t, err)
+	assert.Equal(t, msg.Message, "panic recovered")
+	assert.Equal(t, msg.UnsafeParams["recovered"], "foo")
+}
 
 func TestRunWithFatalLogging_Panic(t *testing.T) {
 	buf := &bytes.Buffer{}
 	ctx := getContextWithLogger(context.Background(), buf)
-	err := RunWithFatalLogging(ctx, func(ctx context.Context) error {
+	err := wapp.RunWithFatalLogging(ctx, func(ctx context.Context) error {
 		panic("foo")
 	})
 	assert.Error(t, err)
@@ -46,7 +62,7 @@ func TestRunWithFatalLogging_Panic(t *testing.T) {
 func TestRunWithFatalLogging_Error(t *testing.T) {
 	buf := &bytes.Buffer{}
 	ctx := getContextWithLogger(context.Background(), buf)
-	err := RunWithFatalLogging(ctx, func(ctx context.Context) error {
+	err := wapp.RunWithFatalLogging(ctx, func(ctx context.Context) error {
 		return werror.Error("foo")
 	})
 	assert.NotNil(t, err)
@@ -57,7 +73,7 @@ func TestRunWithFatalLogging_PanicWithError(t *testing.T) {
 	buf := &bytes.Buffer{}
 	ctx := getContextWithLogger(context.Background(), buf)
 	var panicErr error
-	err := RunWithFatalLogging(ctx, func(ctx context.Context) error {
+	err := wapp.RunWithFatalLogging(ctx, func(ctx context.Context) error {
 		panicErr = werror.Error("foo", werror.SafeParam("verySafeParam", "blah"), werror.UnsafeParam("notSafeParam", "oogabooga"))
 		panic(panicErr)
 	})


### PR DESCRIPTION
It turns out that most usages of `wapp.RunWithFatalLogging` look something like this:
```go
go func() {
	_ = wapp.RunWithFatalLogging(ctx, func(ctx context.Context) error {
		doAThing(ctx)
		return nil
	})
}
```
this can be simplified to
```go
go wapp.RunWithRecoveryLogging(ctx, func(ctx context.Context) {
	doAThing(ctx)
})
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/49)
<!-- Reviewable:end -->
