### PR TITLE
Fix OriginFromCallLine for zap and zerolog

### DIFF
--- a/changelog/@unreleased/pr-74.v2.yml
+++ b/changelog/@unreleased/pr-74.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description:  Fix OriginFromCallLine for zap and zerolog loggers
+  links:
+  - https://github.com/palantir/witchcraft-go-logging/pull/74

--- a/wlog/logger_provider_jsonmarshal.go
+++ b/wlog/logger_provider_jsonmarshal.go
@@ -41,37 +41,33 @@ func (l *jsonMapLogger) Log(params ...Param) {
 func (l *jsonMapLogger) Debug(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel:
-		l.logOutputWithMessage(msg, "DEBUG", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "DEBUG")))
 	}
 }
 
 func (l *jsonMapLogger) Info(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel:
-		l.logOutputWithMessage(msg, "INFO", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "INFO")))
 	}
 }
 
 func (l *jsonMapLogger) Warn(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel, WarnLevel:
-		l.logOutputWithMessage(msg, "WARN", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "WARN")))
 	}
 }
 
 func (l *jsonMapLogger) Error(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel, WarnLevel, ErrorLevel:
-		l.logOutputWithMessage(msg, "ERROR", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "ERROR")))
 	}
 }
 
 func (l *jsonMapLogger) SetLevel(level LogLevel) {
 	l.level = level
-}
-
-func (l *jsonMapLogger) logOutputWithMessage(msg, level string, params []Param) {
-	l.logOutput(append(params, StringParam("message", msg), StringParam("level", level)))
 }
 
 func (l *jsonMapLogger) logOutput(params []Param) {

--- a/wlog/svclog/svc1log/context_test.go
+++ b/wlog/svclog/svc1log/context_test.go
@@ -37,12 +37,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestLogger(w io.Writer, origin string) svc1log.Logger {
-	return svc1log.WithParams(svc1log.NewFromCreator(w, wlog.InfoLevel, wlog.NewJSONMarshalLoggerProvider().NewLeveledLogger), svc1log.Origin(origin))
+func newTestLogger(w io.Writer, origin string, provider wlog.LoggerProvider) svc1log.Logger {
+	return svc1log.WithParams(svc1log.NewFromCreator(w, wlog.InfoLevel, provider.NewLeveledLogger), svc1log.Origin(origin))
 }
 
 func TestFromContext(t *testing.T) {
-	buf, ctx := newBufAndCtxWithLogger()
+	buf, ctx := newBufAndCtxWithLogger(wlog.NewJSONMarshalLoggerProvider())
 
 	logger := svc1log.FromContext(ctx)
 	logger.Info("Test")
@@ -66,7 +66,7 @@ func TestFromContext(t *testing.T) {
 // Tests that the logger returned by svc1log.FromContext has UID, SID and TokenID parameters set on it if the context
 // has those values set on it using wlog.
 func TestFromContextUsesCommonIDs(t *testing.T) {
-	buf, ctx := newBufAndCtxWithLogger()
+	buf, ctx := newBufAndCtxWithLogger(wlog.NewJSONMarshalLoggerProvider())
 
 	ctx = wlog.ContextWithUID(ctx, "test-UID")
 	ctx = wlog.ContextWithSID(ctx, "test-SID")
@@ -96,7 +96,7 @@ func TestFromContextUsesCommonIDs(t *testing.T) {
 
 // Tests that the logger returned by svc1log.FromContext has a TraceID set on it if the context has a wtracing TraceID.
 func TestFromContextSetsTraceID(t *testing.T) {
-	buf, ctx := newBufAndCtxWithLogger()
+	buf, ctx := newBufAndCtxWithLogger(wlog.NewJSONMarshalLoggerProvider())
 
 	// create a no-op tracer to use for the test
 	tracer, err := wzipkin.NewTracer(wtracing.NewNoopReporter())
@@ -156,7 +156,7 @@ func TestFromContextSetsTraceID(t *testing.T) {
 }
 
 func TestWithLoggerParams(t *testing.T) {
-	buf, ctx := newBufAndCtxWithLogger()
+	buf, ctx := newBufAndCtxWithLogger(wlog.NewJSONMarshalLoggerProvider())
 
 	ctx = svc1log.WithLoggerParams(ctx, svc1log.SafeParam("foo", "bar"))
 	ctx = svc1log.WithLoggerParams(ctx, svc1log.SafeParam("ten", 10))
@@ -186,7 +186,7 @@ func TestWithLoggerParams(t *testing.T) {
 }
 
 func TestWParamsSafeAndUnsafeParamsUsed(t *testing.T) {
-	buf, ctx := newBufAndCtxWithLogger()
+	buf, ctx := newBufAndCtxWithLogger(wlog.NewJSONMarshalLoggerProvider())
 
 	ctx = wparams.ContextWithSafeParam(ctx, "foo", "bar")
 	ctx = wparams.ContextWithSafeParam(ctx, "ten", 10)
@@ -219,7 +219,7 @@ func TestWParamsSafeAndUnsafeParamsUsed(t *testing.T) {
 }
 
 func TestWithLoggerParamsSetsWParamsSafeAndUnsafeParams(t *testing.T) {
-	_, ctx := newBufAndCtxWithLogger()
+	_, ctx := newBufAndCtxWithLogger(wlog.NewJSONMarshalLoggerProvider())
 
 	ctx = svc1log.WithLoggerParams(ctx, svc1log.SafeParam("foo", "bar"))
 	ctx = svc1log.WithLoggerParams(ctx, svc1log.UnsafeParam("ten", 10))
@@ -233,94 +233,53 @@ func TestWithLoggerParamsSetsWParamsSafeAndUnsafeParams(t *testing.T) {
 	}, unsafe)
 }
 
-func TestWithJSONLoggerOriginFromCallLine(t *testing.T) {
-	buf, ctx := newBufAndCtxWithLogger()
+func TestWithLoggerOriginFromCallLine(t *testing.T) {
+	for _, test := range []struct{
+		name string
+		provider wlog.LoggerProvider
+	}{
+		{
+			name: "jsonMarshalLogger",
+			provider: wlog.NewJSONMarshalLoggerProvider(),
+		},
+		{
+			name: "zap",
+			provider: wlogzap.LoggerProvider(),
+		},
+		{
+			name: "zerolog",
+			provider: wlogzerolog.LoggerProvider(),
+		},
+	}{
+		t.Run(test.name, func(t *testing.T) {
+			buf, ctx := newBufAndCtxWithLogger(test.provider)
 
-	ctx = svc1log.WithLoggerParams(ctx, svc1log.OriginFromCallLine())
+			ctx = svc1log.WithLoggerParams(ctx, svc1log.OriginFromCallLine())
 
-	logger := svc1log.FromContext(ctx)
-	file, line := getFileAndLine()
-	logger.Info("Test")
+			logger := svc1log.FromContext(ctx)
+			file, line := getFileAndLine()
+			logger.Info("Test")
 
-	entries, err := logreader.EntriesFromContent(buf.Bytes())
-	require.NoError(t, err)
+			entries, err := logreader.EntriesFromContent(buf.Bytes())
+			require.NoError(t, err)
 
-	assert.Equal(t, 1, len(entries))
-	matcher := objmatcher.MapMatcher(map[string]objmatcher.Matcher{
-		"level":   objmatcher.NewEqualsMatcher("INFO"),
-		"time":    objmatcher.NewRegExpMatcher(".+"),
-		"origin":  objmatcher.NewEqualsMatcher(fmt.Sprintf("%s:%d", file, line+1)),
-		"type":    objmatcher.NewEqualsMatcher("service.1"),
-		"message": objmatcher.NewEqualsMatcher("Test"),
-	})
-	err = matcher.Matches(map[string]interface{}(entries[0]))
-	assert.NoError(t, err, "%v", err)
+			assert.Equal(t, 1, len(entries))
+			matcher := objmatcher.MapMatcher(map[string]objmatcher.Matcher{
+				"level":   objmatcher.NewEqualsMatcher("INFO"),
+				"time":    objmatcher.NewRegExpMatcher(".+"),
+				"origin":  objmatcher.NewEqualsMatcher(fmt.Sprintf("%s:%d", file, line+1)),
+				"type":    objmatcher.NewEqualsMatcher("service.1"),
+				"message": objmatcher.NewEqualsMatcher("Test"),
+			})
+			err = matcher.Matches(map[string]interface{}(entries[0]))
+			assert.NoError(t, err, "%v", err)
+		})
+	}
 }
 
-func TestWithZapLoggerOriginFromCallLine(t *testing.T) {
-	buf, ctx := newBufAndCtxWithZapLogger()
-
-	ctx = svc1log.WithLoggerParams(ctx, svc1log.OriginFromCallLine())
-
-	logger := svc1log.FromContext(ctx)
-	file, line := getFileAndLine()
-	logger.Info("Test")
-
-	entries, err := logreader.EntriesFromContent(buf.Bytes())
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(entries))
-	matcher := objmatcher.MapMatcher(map[string]objmatcher.Matcher{
-		"level":   objmatcher.NewEqualsMatcher("INFO"),
-		"time":    objmatcher.NewRegExpMatcher(".+"),
-		"origin":  objmatcher.NewEqualsMatcher(fmt.Sprintf("%s:%d", file, line+1)),
-		"type":    objmatcher.NewEqualsMatcher("service.1"),
-		"message": objmatcher.NewEqualsMatcher("Test"),
-	})
-	err = matcher.Matches(map[string]interface{}(entries[0]))
-	assert.NoError(t, err, "%v", err)
-}
-
-func TestWithZeroLoggerOriginFromCallLine(t *testing.T) {
-	buf, ctx := newBufAndCtxWithZeroLogger()
-
-	ctx = svc1log.WithLoggerParams(ctx, svc1log.OriginFromCallLine())
-
-	logger := svc1log.FromContext(ctx)
-	file, line := getFileAndLine()
-	logger.Info("Test")
-
-	entries, err := logreader.EntriesFromContent(buf.Bytes())
-	require.NoError(t, err)
-
-	assert.Equal(t, 1, len(entries))
-	matcher := objmatcher.MapMatcher(map[string]objmatcher.Matcher{
-		"level":   objmatcher.NewEqualsMatcher("INFO"),
-		"time":    objmatcher.NewRegExpMatcher(".+"),
-		"origin":  objmatcher.NewEqualsMatcher(fmt.Sprintf("%s:%d", file, line+1)),
-		"type":    objmatcher.NewEqualsMatcher("service.1"),
-		"message": objmatcher.NewEqualsMatcher("Test"),
-	})
-	err = matcher.Matches(map[string]interface{}(entries[0]))
-	assert.NoError(t, err, "%v", err)
-}
-
-func newBufAndCtxWithLogger() (*bytes.Buffer, context.Context) {
+func newBufAndCtxWithLogger(provider wlog.LoggerProvider) (*bytes.Buffer, context.Context) {
 	buf := &bytes.Buffer{}
-	ctx := svc1log.WithLogger(context.Background(), newTestLogger(buf, "com.palantir.test"))
-	return buf, ctx
-}
-
-func newBufAndCtxWithZapLogger() (*bytes.Buffer, context.Context) {
-	wlog.SetDefaultLoggerProvider(wlogzap.LoggerProvider())
-	buf := &bytes.Buffer{}
-	ctx := svc1log.WithLogger(context.Background(), svc1log.New(buf, wlog.InfoLevel))
-	return buf, ctx
-}
-
-func newBufAndCtxWithZeroLogger() (*bytes.Buffer, context.Context) {
-	wlog.SetDefaultLoggerProvider(wlogzerolog.LoggerProvider())
-	buf := &bytes.Buffer{}
-	ctx := svc1log.WithLogger(context.Background(), svc1log.New(buf, wlog.InfoLevel))
+	ctx := svc1log.WithLogger(context.Background(), newTestLogger(buf, "com.palantir.test", provider))
 	return buf, ctx
 }
 

--- a/wlog/svclog/svc1log/context_test.go
+++ b/wlog/svclog/svc1log/context_test.go
@@ -19,12 +19,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/palantir/witchcraft-go-logging/internal/gopath"
 	"io"
 	"runtime"
 	"testing"
 
 	"github.com/palantir/pkg/objmatcher"
+	"github.com/palantir/witchcraft-go-logging/internal/gopath"
 	"github.com/palantir/witchcraft-go-logging/wlog"
 	wlogzap "github.com/palantir/witchcraft-go-logging/wlog-zap"
 	wlogzerolog "github.com/palantir/witchcraft-go-logging/wlog-zerolog"
@@ -234,23 +234,23 @@ func TestWithLoggerParamsSetsWParamsSafeAndUnsafeParams(t *testing.T) {
 }
 
 func TestWithLoggerOriginFromCallLine(t *testing.T) {
-	for _, test := range []struct{
-		name string
+	for _, test := range []struct {
+		name     string
 		provider wlog.LoggerProvider
 	}{
 		{
-			name: "jsonMarshalLogger",
+			name:     "jsonMarshalLogger",
 			provider: wlog.NewJSONMarshalLoggerProvider(),
 		},
 		{
-			name: "zap",
+			name:     "zap",
 			provider: wlogzap.LoggerProvider(),
 		},
 		{
-			name: "zerolog",
+			name:     "zerolog",
 			provider: wlogzerolog.LoggerProvider(),
 		},
-	}{
+	} {
 		t.Run(test.name, func(t *testing.T) {
 			buf, ctx := newBufAndCtxWithLogger(test.provider)
 

--- a/wlog/svclog/svc1log/params.go
+++ b/wlog/svclog/svc1log/params.go
@@ -119,7 +119,7 @@ func OriginFromInitPkg(skipPkg int) Param {
 func OriginFromCallLine() Param {
 	return paramFunc(func(entry wlog.LogEntry) {
 		origin := ""
-		if file, line, ok := initLineCaller(9); ok {
+		if file, line, ok := initLineCaller(8); ok {
 			origin = file + ":" + strconv.Itoa(line)
 		}
 		entry.OptionalStringValue(OriginKey, origin)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The current `OriginFromCallLine` does not have the correct behavior for `wlogzap` or `wlogzerolog` logger implementations, both of which are used in production. The previous behavior was correct for the `JSONMarshalLogger` due to an implementation difference that resulted in a different number of frames on the stack.

## After this PR
The implementation for the `JSONMarshalLogger` has been updated to make it consistent with the other loggers, and the number of frames to skip to get the filename and line number has been fixed. Tests have also been added to verify the behavior across logger types.

==COMMIT_MSG==
Fix OriginFromCallLine for zap and zerolog loggers
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
I can't think of any, but it could break people who were depending on the previous behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/74)
<!-- Reviewable:end -->
