### PR TITLE
Fix: export req2log.TypeValue

### DIFF
--- a/changelog/@unreleased/pr-85.v2.yml
+++ b/changelog/@unreleased/pr-85.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Exports reqe2log.TypeValue for consistency with all of the other logger
+    types.
+  links:
+  - https://github.com/palantir/witchcraft-go-logging/pull/85

--- a/wlog/reqlog/req2log/logger.go
+++ b/wlog/reqlog/req2log/logger.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	typeValue = "request.2"
+	TypeValue = "request.2"
 
 	methodKey       = "method"
 	protocolKey     = "protocol"

--- a/wlog/reqlog/req2log/logger_default.go
+++ b/wlog/reqlog/req2log/logger_default.go
@@ -42,7 +42,7 @@ func (l *defaultLogger) Request(r Request) {
 	idsMap := l.idsExtractor.ExtractIDs(r.Request)
 
 	l.logger.Log(
-		wlog.StringParam(wlog.TypeKey, typeValue),
+		wlog.StringParam(wlog.TypeKey, TypeValue),
 		wlog.OptionalStringParam(methodKey, r.Request.Method),
 		wlog.StringParam(protocolKey, r.Request.Proto),
 		wlog.StringParam(pathKey, reqPath),


### PR DESCRIPTION
## Before this PR
`reqlog.typeValue` is not exported. Having the type value available can be helpful for consumers, and every other logger type in this repository exports their `TypeValue`.

## After this PR
==COMMIT_MSG==
Exports reqe2log.TypeValue for consistency with all of the other logger types.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/85)
<!-- Reviewable:end -->
