### PR TITLE
Allow configuration of OriginFromCallLine stack frame skips

### DIFF
--- a/wlog/svclog/svc1log/params.go
+++ b/wlog/svclog/svc1log/params.go
@@ -106,10 +106,12 @@ func OriginFromInitPkg(skipPkg int) Param {
 	return Origin(CallerPkg(1, 0))
 }
 
-var originFromCallLineSkip = 8
+var defaultOriginFromCallLineStackSkip = 8
 
-func SetOriginFromCallLineDefaultSkip(skip int) {
-	originFromCallLineSkip = skip
+// SetOriginFromCallLineStackSkip sets the number of frames that OriginFromCallLine should skip to identify the filename
+// and line of the logger invocation.
+func SetOriginFromCallLineStackSkip(skip int) {
+	defaultOriginFromCallLineStackSkip = skip
 }
 
 // OriginFromCallLine sets the "origin" field to be the filename and line of the location at which the logger invocation
@@ -121,11 +123,11 @@ func SetOriginFromCallLineDefaultSkip(skip int) {
 // Note that this parameter is tied to the implementation details of the logger implementations defined in the svc1log
 // package (it hard-codes assumptions relating to the number of call stacks that must be skipped to reach the log site).
 // Using this parameter with an svc1log.Logger implementation not defined in the svc1log package may result in incorrect
-// output.
+// output unless the implementation explicitly states that it handles this correctly.
 func OriginFromCallLine() Param {
 	return paramFunc(func(entry wlog.LogEntry) {
 		origin := ""
-		if file, line, ok := initLineCaller(originFromCallLineSkip); ok {
+		if file, line, ok := initLineCaller(defaultOriginFromCallLineStackSkip); ok {
 			origin = file + ":" + strconv.Itoa(line)
 		}
 		entry.OptionalStringValue(OriginKey, origin)

--- a/wlog/svclog/svc1log/params.go
+++ b/wlog/svclog/svc1log/params.go
@@ -106,6 +106,12 @@ func OriginFromInitPkg(skipPkg int) Param {
 	return Origin(CallerPkg(1, 0))
 }
 
+var originFromCallLineSkip = 8
+
+func SetOriginFromCallLineDefaultSkip(skip int) {
+	originFromCallLineSkip = skip
+}
+
 // OriginFromCallLine sets the "origin" field to be the filename and line of the location at which the logger invocation
 // is performed.
 //
@@ -119,7 +125,7 @@ func OriginFromInitPkg(skipPkg int) Param {
 func OriginFromCallLine() Param {
 	return paramFunc(func(entry wlog.LogEntry) {
 		origin := ""
-		if file, line, ok := initLineCaller(8); ok {
+		if file, line, ok := initLineCaller(originFromCallLineSkip); ok {
 			origin = file + ":" + strconv.Itoa(line)
 		}
 		entry.OptionalStringValue(OriginKey, origin)


### PR DESCRIPTION
## Before this PR
Service loggers defined outside of this package were not able to use OriginFromCallLine. The `origin` parameter was not set correctly because the number of stack frames to skip was hardcoded and would not work for wrapped loggers.

## After this PR
==COMMIT_MSG==
Allow configuration of OriginFromCallLine stack frame skips
==COMMIT_MSG==

## Possible downsides?
This exposes some of the internals of the OriginFromCallLine logging implementation that may not be desirable.

Another approach would be to include `OriginFromCallLine` as a svclogger interface function, which would force all implementers of the interface to define their own version of that function. That would introduce breaking changes to the API, so I was hesitant to start with that. 

I'd be happy to hear any feedback on this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/93)
<!-- Reviewable:end -->
