### PR TITLE
Improvement: Expose RunWithRecoveryLoggingWithError under the wapp package

### DIFF
--- a/changelog/@unreleased/pr-108.v2.yml
+++ b/changelog/@unreleased/pr-108.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Expose RunWithRecoveryLoggingWithError under the wapp package
+  links:
+  - https://github.com/palantir/witchcraft-go-logging/pull/108

--- a/wlog/wapp/fatal.go
+++ b/wlog/wapp/fatal.go
@@ -39,9 +39,9 @@ func RunWithFatalLogging(ctx context.Context, runFn func(ctx context.Context) er
 	return runWithFatalLoggingInternal(ctx, runFn, true)
 }
 
-// RunWithFatalLoggingNoNonPanicLogging is identical to RunWithFatalLogging however it only emits logs on panics, not if runFn a normal error
+// RunWithRecoveryLoggingWithError is identical to RunWithFatalLogging however it only emits logs on panics, not if runFn a normal error
 // This can be useful if you want to special case the logging of this error but still want a centralized place to handle panics
-func RunWithFatalLoggingNoNonPanicLogging(ctx context.Context, runFn func(ctx context.Context) error) (retErr error) {
+func RunWithRecoveryLoggingWithError(ctx context.Context, runFn func(ctx context.Context) error) (retErr error) {
 	return runWithFatalLoggingInternal(ctx, runFn, false)
 }
 

--- a/wlog/wapp/fatal.go
+++ b/wlog/wapp/fatal.go
@@ -33,24 +33,19 @@ func RunWithRecoveryLogging(ctx context.Context, runFn func(ctx context.Context)
 	})
 }
 
-func RunWithRecoveryLoggingNoLog(ctx context.Context, runFn func(ctx context.Context)) {
-	_ = RunWithFatalLoggingNoLog(ctx, func(ctx context.Context) error {
-		runFn(ctx)
-		return nil
-	})
-}
-
 // RunWithFatalLogging wraps a callback, logging errors and panics it returns.
 // Useful as a "catch all" for applications so that they can log fatal events, perhaps before exiting.
 func RunWithFatalLogging(ctx context.Context, runFn func(ctx context.Context) error) (retErr error) {
-	return runWithFatalLoggingI(ctx, runFn, true)
+	return runWithFatalLoggingInternal(ctx, runFn, true)
 }
 
-func RunWithFatalLoggingNoLog(ctx context.Context, runFn func(ctx context.Context) error) (retErr error) {
-	return runWithFatalLoggingI(ctx, runFn, false)
+// RunWithFatalLoggingNoNonPanicLogging is identical to RunWithFatalLogging however it only emits logs on panics, not if runFn a normal error
+// This can be useful if you want to special case the logging of this error but still want a centralized place to handle panics
+func RunWithFatalLoggingNoNonPanicLogging(ctx context.Context, runFn func(ctx context.Context) error) (retErr error) {
+	return runWithFatalLoggingInternal(ctx, runFn, false)
 }
 
-func runWithFatalLoggingI(ctx context.Context, runFn func(ctx context.Context) error, logAnyError bool) (retErr error) {
+func runWithFatalLoggingInternal(ctx context.Context, runFn func(ctx context.Context) error, logAnyError bool) (retErr error) {
 	defer func() {
 		r := recover()
 		if r == nil {

--- a/wlog/wapp/fatal.go
+++ b/wlog/wapp/fatal.go
@@ -50,7 +50,6 @@ func RunWithFatalLoggingNoLog(ctx context.Context, runFn func(ctx context.Contex
 	return runWithFatalLoggingI(ctx, runFn, false)
 }
 
-
 func runWithFatalLoggingI(ctx context.Context, runFn func(ctx context.Context) error, logAnyError bool) (retErr error) {
 	defer func() {
 		r := recover()

--- a/wlog/wapp/fatal_test.go
+++ b/wlog/wapp/fatal_test.go
@@ -72,7 +72,7 @@ func TestRunWithFatalLogging_Error(t *testing.T) {
 func TestRunRunWithFatalLoggingNoLog_Error(t *testing.T) {
 	buf := &bytes.Buffer{}
 	ctx := getContextWithLogger(context.Background(), buf)
-	err := wapp.RunWithFatalLoggingNoNonPanicLogging(ctx, func(ctx context.Context) error {
+	err := wapp.RunWithRecoveryLoggingWithError(ctx, func(ctx context.Context) error {
 		return werror.Error("foo")
 	})
 	assert.NotNil(t, err)
@@ -118,7 +118,7 @@ func getContextWithLogger(ctx context.Context, writer io.Writer) context.Context
 func TestRunRunWithFatalLoggingNoErrors(t *testing.T) {
 	buf := &bytes.Buffer{}
 	ctx := getContextWithLogger(context.Background(), buf)
-	err := wapp.RunWithFatalLoggingNoNonPanicLogging(ctx, func(ctx context.Context) error {
+	err := wapp.RunWithRecoveryLoggingWithError(ctx, func(ctx context.Context) error {
 		return nil
 	})
 	assert.NoError(t, err)

--- a/wlog/wapp/fatal_test.go
+++ b/wlog/wapp/fatal_test.go
@@ -69,6 +69,16 @@ func TestRunWithFatalLogging_Error(t *testing.T) {
 	assert.Contains(t, buf.String(), "foo")
 }
 
+func TestRunRunWithFatalLoggingNoLog_Error(t *testing.T) {
+	buf := &bytes.Buffer{}
+	ctx := getContextWithLogger(context.Background(), buf)
+	err := wapp.RunWithFatalLoggingNoNonPanicLogging(ctx, func(ctx context.Context) error {
+		return werror.Error("foo")
+	})
+	assert.NotNil(t, err)
+	assert.NotContains(t, buf.String(), "foo")
+}
+
 func TestRunWithFatalLogging_PanicWithError(t *testing.T) {
 	buf := &bytes.Buffer{}
 	ctx := getContextWithLogger(context.Background(), buf)
@@ -103,4 +113,14 @@ func getContextWithLogger(ctx context.Context, writer io.Writer) context.Context
 	logger := svc1log.New(writer, wlog.DebugLevel)
 	ctx = svc1log.WithLogger(ctx, logger)
 	return ctx
+}
+
+func TestRunRunWithFatalLoggingNoErrors(t *testing.T) {
+	buf := &bytes.Buffer{}
+	ctx := getContextWithLogger(context.Background(), buf)
+	err := wapp.RunWithFatalLoggingNoNonPanicLogging(ctx, func(ctx context.Context) error {
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Empty(t, buf.String())
 }


### PR DESCRIPTION
- Improvement: Expose RunWithRecoveryLoggingWithError under the wapp package
- This function is very similar to `RunWithFatalLogging` however it does not emit service logs for non-panics. This can be desirable if we are in a situation where we want to handle the logging of errors in a preferred way, however we do not want to reinvent the wheel in terms of catching and handling panics
- Add a slightly orthogonal test called `TestRunRunWithFatalLoggingNoErrors` to test the happy case of this code

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/108)
<!-- Reviewable:end -->
