### PR TITLE
Remove time, level, and message keys in logger provider

### DIFF
--- a/changelog/@unreleased/pr-123.v2.yml
+++ b/changelog/@unreleased/pr-123.v2.yml
@@ -1,5 +1,8 @@
 type: improvement
 improvement:
-  description: remove time, level, and message keys in logger provider
+  description: |
+    Removes the time, level and message keys from the loggers returned by implementations of the LoggerProvider interface.
+    Previously, wlog.Logger instances returned by the LoggerProvider interface set "time" as a top-level key and wlog.LeveledLogger instances returned by the LoggerProvider interface set "time", "level" and "message" as top-level keys. After this change, these top-level keys are no longer set. This allows the underlying logger interfaces to be used by logger implementations that may not set these top-level keys in their output.
+    Log type implementations that use these loggers may no longer assume that these keys are set and must set them themselves if they are desired in the output. Existing implementations have all been updated to do so, so there should be no behavioral changes.
   links:
   - https://github.com/palantir/witchcraft-go-logging/pull/123

--- a/changelog/@unreleased/pr-123.v2.yml
+++ b/changelog/@unreleased/pr-123.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: remove time, level, and message keys in logger provider
+  links:
+  - https://github.com/palantir/witchcraft-go-logging/pull/123

--- a/wlog-glog/internal/logger.go
+++ b/wlog-glog/internal/logger.go
@@ -51,16 +51,10 @@ func (*gLogger) SetLevel(level wlog.LogLevel) {
 
 func createGLogMsg(msg string, params []wlog.Param) string {
 	entry := wlog.NewMapLogEntry()
-	wlog.ApplyParams(entry, params)
-
-	var parts []string
-	if msg != "" {
-		parts = append(parts, msg)
-	}
-	parts = append(parts, paramsToLog(entry)...)
+	wlog.ApplyParams(entry, wlog.ParamsWithMessage(msg, params))
 
 	// TODO: ignore/omit unsafe params?
-	return strings.Join(parts, ", ")
+	return strings.Join(paramsToLog(entry), ", ")
 }
 
 // paramsToLog returns the parameters to log as strings of the form "<key>: <value>".

--- a/wlog-zap/internal/logger.go
+++ b/wlog-zap/internal/logger.go
@@ -148,6 +148,7 @@ func (l *zapLogger) SetLevel(level wlog.LogLevel) {
 func logOutput(logFn func(string, ...zap.Field), msg string, params []wlog.Param) {
 	entry := newZapLogEntry()
 	wlog.ApplyParams(entry, wlog.ParamsWithMessage(msg, params))
+	// Empty string is used for the "message" because the message is added to params above if present
 	logFn("", entry.Fields()...)
 }
 

--- a/wlog-zap/internal/logger.go
+++ b/wlog-zap/internal/logger.go
@@ -147,8 +147,8 @@ func (l *zapLogger) SetLevel(level wlog.LogLevel) {
 
 func logOutput(logFn func(string, ...zap.Field), msg string, params []wlog.Param) {
 	entry := newZapLogEntry()
-	wlog.ApplyParams(entry, params)
-	logFn(msg, entry.Fields()...)
+	wlog.ApplyParams(entry, wlog.ParamsWithMessage(msg, params))
+	logFn("", entry.Fields()...)
 }
 
 func encodeField(key string, value interface{}, enc zapcore.ObjectEncoder) error {

--- a/wlog-zap/internal/provider.go
+++ b/wlog-zap/internal/provider.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/palantir/witchcraft-go-logging/wlog"
-	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -33,7 +32,6 @@ type loggerProvider struct{}
 
 func (lp *loggerProvider) NewLogger(w io.Writer) wlog.Logger {
 	logger, atomicLevel := newZapLogger(w, wlog.InfoLevel, zapcore.EncoderConfig{
-		TimeKey:        wlog.TimeKey,
 		EncodeTime:     rfc3339NanoTimeEncoder,
 		EncodeDuration: zapcore.NanosDurationEncoder,
 	})
@@ -45,12 +43,9 @@ func (lp *loggerProvider) NewLogger(w io.Writer) wlog.Logger {
 
 func (lp *loggerProvider) NewLeveledLogger(w io.Writer, level wlog.LogLevel) wlog.LeveledLogger {
 	logger, atomicLevel := newZapLogger(w, level, zapcore.EncoderConfig{
-		TimeKey:        wlog.TimeKey,
 		EncodeTime:     rfc3339NanoTimeEncoder,
 		EncodeDuration: zapcore.NanosDurationEncoder,
-		LevelKey:       svc1log.LevelKey,
 		EncodeLevel:    zapcore.CapitalLevelEncoder,
-		MessageKey:     svc1log.MessageKey,
 	})
 	return &zapLogger{
 		logger: logger,

--- a/wlog-zerolog/internal/logger.go
+++ b/wlog-zerolog/internal/logger.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/palantir/witchcraft-go-logging/wlog"
 	"github.com/palantir/witchcraft-go-logging/wlog-zerolog/internal/marshalers"
-	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/rs/zerolog"
 )
 
@@ -177,35 +176,35 @@ func (l *zeroLogger) Log(params ...wlog.Param) {
 	if !l.should(zerolog.NoLevel) {
 		return
 	}
-	logOutput(l.logger.Log, "", "", params)
+	logOutput(l.logger.Log, "", params)
 }
 
 func (l *zeroLogger) Debug(msg string, params ...wlog.Param) {
 	if !l.should(zerolog.DebugLevel) {
 		return
 	}
-	logOutput(l.logger.Log, msg, svc1log.LevelDebugValue, params)
+	logOutput(l.logger.Log, msg, params)
 }
 
 func (l *zeroLogger) Info(msg string, params ...wlog.Param) {
 	if !l.should(zerolog.InfoLevel) {
 		return
 	}
-	logOutput(l.logger.Log, msg, svc1log.LevelInfoValue, params)
+	logOutput(l.logger.Log, msg, params)
 }
 
 func (l *zeroLogger) Warn(msg string, params ...wlog.Param) {
 	if !l.should(zerolog.WarnLevel) {
 		return
 	}
-	logOutput(l.logger.Log, msg, svc1log.LevelWarnValue, params)
+	logOutput(l.logger.Log, msg, params)
 }
 
 func (l *zeroLogger) Error(msg string, params ...wlog.Param) {
 	if !l.should(zerolog.ErrorLevel) {
 		return
 	}
-	logOutput(l.logger.Log, msg, svc1log.LevelErrorValue, params)
+	logOutput(l.logger.Log, msg, params)
 }
 
 func (l *zeroLogger) SetLevel(level wlog.LogLevel) {
@@ -219,7 +218,7 @@ func reverseParams(params []wlog.Param) {
 	}
 }
 
-func logOutput(newEvt func() *zerolog.Event, msg, levelVal string, params []wlog.Param) {
+func logOutput(newEvt func() *zerolog.Event, msg string, params []wlog.Param) {
 	entry := &zeroLogEntry{
 		evt:  newEvt(),
 		keys: make(map[string]struct{}),

--- a/wlog-zerolog/internal/logger.go
+++ b/wlog-zerolog/internal/logger.go
@@ -16,7 +16,6 @@ package zeroimpl
 
 import (
 	"reflect"
-	"time"
 
 	"github.com/palantir/witchcraft-go-logging/wlog"
 	"github.com/palantir/witchcraft-go-logging/wlog-zerolog/internal/marshalers"
@@ -227,10 +226,6 @@ func logOutput(newEvt func() *zerolog.Event, msg, levelVal string, params []wlog
 	}
 	if !entry.evt.Enabled() {
 		return
-	}
-	entry.evt = entry.evt.Str(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
-	if levelVal != "" {
-		entry.evt = entry.evt.Str(svc1log.LevelKey, levelVal)
 	}
 	reverseParams(params)
 	wlog.ApplyParams(entry, params)

--- a/wlog/auditlog/audit2log/logger_default.go
+++ b/wlog/auditlog/audit2log/logger_default.go
@@ -15,6 +15,8 @@
 package audit2log
 
 import (
+	"time"
+
 	"github.com/palantir/witchcraft-go-logging/wlog"
 )
 
@@ -39,5 +41,6 @@ func toParams(name string, result AuditResultType, inParams []Param) []wlog.Para
 var defaultTypeParam = []wlog.Param{
 	wlog.NewParam(func(entry wlog.LogEntry) {
 		entry.StringValue(wlog.TypeKey, TypeValue)
+		entry.StringValue(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
 	}),
 }

--- a/wlog/diaglog/diag1log/logger_default.go
+++ b/wlog/diaglog/diag1log/logger_default.go
@@ -15,6 +15,8 @@
 package diag1log
 
 import (
+	"time"
+
 	"github.com/palantir/witchcraft-go-logging/conjure/witchcraft/api/logging"
 	"github.com/palantir/witchcraft-go-logging/wlog"
 )
@@ -40,5 +42,6 @@ func toParams(diagnostic logging.Diagnostic, inParams []Param) []wlog.Param {
 var defaultTypeParam = []wlog.Param{
 	wlog.NewParam(func(entry wlog.LogEntry) {
 		entry.StringValue(wlog.TypeKey, TypeValue)
+		entry.StringValue(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
 	}),
 }

--- a/wlog/evtlog/evt2log/logger_default.go
+++ b/wlog/evtlog/evt2log/logger_default.go
@@ -15,6 +15,8 @@
 package evt2log
 
 import (
+	"time"
+
 	"github.com/palantir/witchcraft-go-logging/wlog"
 )
 
@@ -39,5 +41,6 @@ func toParams(evtName string, inParams []Param) []wlog.Param {
 var defaultTypeParam = []wlog.Param{
 	wlog.NewParam(func(entry wlog.LogEntry) {
 		entry.StringValue(wlog.TypeKey, TypeValue)
+		entry.StringValue(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
 	}),
 }

--- a/wlog/logger_provider_jsonmarshal.go
+++ b/wlog/logger_provider_jsonmarshal.go
@@ -41,28 +41,28 @@ func (l *jsonMapLogger) Log(params ...Param) {
 func (l *jsonMapLogger) Debug(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel:
-		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "DEBUG")))
+		l.logOutput(append([]Param{StringParam("message", msg), StringParam("level", "DEBUG")}, params...))
 	}
 }
 
 func (l *jsonMapLogger) Info(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel:
-		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "INFO")))
+		l.logOutput(append([]Param{StringParam("message", msg), StringParam("level", "INFO")}, params...))
 	}
 }
 
 func (l *jsonMapLogger) Warn(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel, WarnLevel:
-		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "WARN")))
+		l.logOutput(append([]Param{StringParam("message", msg), StringParam("level", "WARN")}, params...))
 	}
 }
 
 func (l *jsonMapLogger) Error(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel, WarnLevel, ErrorLevel:
-		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "ERROR")))
+		l.logOutput(append([]Param{StringParam("message", msg), StringParam("level", "ERROR")}, params...))
 	}
 }
 

--- a/wlog/logger_provider_jsonmarshal.go
+++ b/wlog/logger_provider_jsonmarshal.go
@@ -41,28 +41,28 @@ func (l *jsonMapLogger) Log(params ...Param) {
 func (l *jsonMapLogger) Debug(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel:
-		l.logOutput(append([]Param{StringParam("message", msg), StringParam("level", "DEBUG")}, params...))
+		l.logOutput(ParamsWithMessage(msg, params))
 	}
 }
 
 func (l *jsonMapLogger) Info(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel:
-		l.logOutput(append([]Param{StringParam("message", msg), StringParam("level", "INFO")}, params...))
+		l.logOutput(ParamsWithMessage(msg, params))
 	}
 }
 
 func (l *jsonMapLogger) Warn(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel, WarnLevel:
-		l.logOutput(append([]Param{StringParam("message", msg), StringParam("level", "WARN")}, params...))
+		l.logOutput(ParamsWithMessage(msg, params))
 	}
 }
 
 func (l *jsonMapLogger) Error(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel, WarnLevel, ErrorLevel:
-		l.logOutput(append([]Param{StringParam("message", msg), StringParam("level", "ERROR")}, params...))
+		l.logOutput(ParamsWithMessage(msg, params))
 	}
 }
 

--- a/wlog/metriclog/metric1log/logger_default.go
+++ b/wlog/metriclog/metric1log/logger_default.go
@@ -15,6 +15,8 @@
 package metric1log
 
 import (
+	"time"
+
 	"github.com/palantir/witchcraft-go-logging/wlog"
 )
 
@@ -39,5 +41,6 @@ func toParams(metricName, metricType string, inParams []Param) []wlog.Param {
 var defaultTypeParam = []wlog.Param{
 	wlog.NewParam(func(entry wlog.LogEntry) {
 		entry.StringValue(wlog.TypeKey, TypeValue)
+		entry.StringValue(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
 	}),
 }

--- a/wlog/params.go
+++ b/wlog/params.go
@@ -55,6 +55,14 @@ func ApplyParams(logger LogEntry, params []Param) {
 	}
 }
 
+// Appends a StringParam with the msg string if non-empty
+func ParamsWithMessage(msg string, params []Param) []Param {
+	if msg != "" {
+		return append(params, StringParam("message", msg))
+	}
+	return params
+}
+
 type paramFunc func(logger LogEntry)
 
 func (f paramFunc) apply(logger LogEntry) {

--- a/wlog/params.go
+++ b/wlog/params.go
@@ -55,7 +55,7 @@ func ApplyParams(logger LogEntry, params []Param) {
 	}
 }
 
-// Appends a StringParam with the msg string if non-empty
+// ParamsWithMessage appends a StringParam with the msg string if non-empty
 func ParamsWithMessage(msg string, params []Param) []Param {
 	if msg != "" {
 		return append(params, StringParam("message", msg))

--- a/wlog/params.go
+++ b/wlog/params.go
@@ -55,7 +55,9 @@ func ApplyParams(logger LogEntry, params []Param) {
 	}
 }
 
-// ParamsWithMessage appends a StringParam with the msg string if non-empty
+// ParamsWithMessage returns a new slice that appends a StringParam with the key "message" and
+// value of the provided msg parameter if it is non-empty. If msg is empty, returns the provided slice
+// without modification.
 func ParamsWithMessage(msg string, params []Param) []Param {
 	if msg != "" {
 		return append(params, StringParam("message", msg))

--- a/wlog/reqlog/req2log/logger_default.go
+++ b/wlog/reqlog/req2log/logger_default.go
@@ -16,6 +16,7 @@ package req2log
 
 import (
 	"strings"
+	"time"
 
 	"github.com/palantir/witchcraft-go-logging/wlog"
 	"github.com/palantir/witchcraft-go-logging/wlog/extractor"
@@ -43,6 +44,7 @@ func (l *defaultLogger) Request(r Request) {
 
 	l.logger.Log(
 		wlog.StringParam(wlog.TypeKey, TypeValue),
+		wlog.StringParam(wlog.TimeKey, time.Now().Format(time.RFC3339Nano)),
 		wlog.OptionalStringParam(methodKey, r.Request.Method),
 		wlog.StringParam(protocolKey, r.Request.Proto),
 		wlog.StringParam(pathKey, reqPath),

--- a/wlog/svclog/svc1log/logger_default.go
+++ b/wlog/svclog/svc1log/logger_default.go
@@ -57,20 +57,20 @@ type defaultLogger struct {
 }
 
 func (l *defaultLogger) Debug(msg string, params ...Param) {
-	l.logger.Debug("", toParams(msg, DebugLevelParam(), params)...)
+	l.logger.Debug(msg, toParams(msg, DebugLevelParam(), params)...)
 }
 
 func (l *defaultLogger) Info(msg string, params ...Param) {
-	l.logger.Info("", toParams(msg, InfoLevelParam(), params)...)
+	l.logger.Info(msg, toParams(msg, InfoLevelParam(), params)...)
 
 }
 
 func (l *defaultLogger) Warn(msg string, params ...Param) {
-	l.logger.Warn("", toParams(msg, WarnLevelParam(), params)...)
+	l.logger.Warn(msg, toParams(msg, WarnLevelParam(), params)...)
 }
 
 func (l *defaultLogger) Error(msg string, params ...Param) {
-	l.logger.Error("", toParams(msg, ErrorLevelParam(), params)...)
+	l.logger.Error(msg, toParams(msg, ErrorLevelParam(), params)...)
 }
 
 func (l *defaultLogger) SetLevel(level wlog.LogLevel) {
@@ -78,14 +78,11 @@ func (l *defaultLogger) SetLevel(level wlog.LogLevel) {
 }
 
 func toParams(msg string, level wlog.Param, inParams []Param) []wlog.Param {
-	outParams := make([]wlog.Param, len(defaultTypeParam)+2+len(inParams))
+	outParams := make([]wlog.Param, len(defaultTypeParam)+1+len(inParams))
 	copy(outParams, defaultTypeParam)
 	outParams[len(defaultTypeParam)] = level
-	outParams[len(defaultTypeParam)+1] = wlog.NewParam(func(entry wlog.LogEntry) {
-		entry.StringValue(MessageKey, msg)
-	})
 	for idx := range inParams {
-		outParams[len(defaultTypeParam)+2+idx] = wlog.NewParam(inParams[idx].apply)
+		outParams[len(defaultTypeParam)+1+idx] = wlog.NewParam(inParams[idx].apply)
 	}
 	return outParams
 }

--- a/wlog/svclog/svc1log/logger_default.go
+++ b/wlog/svclog/svc1log/logger_default.go
@@ -57,27 +57,27 @@ type defaultLogger struct {
 }
 
 func (l *defaultLogger) Debug(msg string, params ...Param) {
-	l.logger.Debug(msg, toParams(msg, DebugLevelParam(), params)...)
+	l.logger.Debug(msg, toParams(DebugLevelParam(), params)...)
 }
 
 func (l *defaultLogger) Info(msg string, params ...Param) {
-	l.logger.Info(msg, toParams(msg, InfoLevelParam(), params)...)
+	l.logger.Info(msg, toParams(InfoLevelParam(), params)...)
 
 }
 
 func (l *defaultLogger) Warn(msg string, params ...Param) {
-	l.logger.Warn(msg, toParams(msg, WarnLevelParam(), params)...)
+	l.logger.Warn(msg, toParams(WarnLevelParam(), params)...)
 }
 
 func (l *defaultLogger) Error(msg string, params ...Param) {
-	l.logger.Error(msg, toParams(msg, ErrorLevelParam(), params)...)
+	l.logger.Error(msg, toParams(ErrorLevelParam(), params)...)
 }
 
 func (l *defaultLogger) SetLevel(level wlog.LogLevel) {
 	l.logger.SetLevel(level)
 }
 
-func toParams(msg string, level wlog.Param, inParams []Param) []wlog.Param {
+func toParams(level wlog.Param, inParams []Param) []wlog.Param {
 	outParams := make([]wlog.Param, len(defaultTypeParam)+1+len(inParams))
 	copy(outParams, defaultTypeParam)
 	outParams[len(defaultTypeParam)] = level

--- a/wlog/svclog/svc1log/logger_default.go
+++ b/wlog/svclog/svc1log/logger_default.go
@@ -21,6 +21,7 @@ import (
 )
 
 var (
+	// Level params declared as variables so that they are only allocated once
 	debugLevelParam = wlog.NewParam(func(entry wlog.LogEntry) {
 		entry.StringValue(LevelKey, LevelDebugValue)
 	})

--- a/wlog/trclog/trc1log/logger_default.go
+++ b/wlog/trclog/trc1log/logger_default.go
@@ -16,6 +16,7 @@ package trc1log
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/palantir/witchcraft-go-logging/wlog"
 	"github.com/palantir/witchcraft-go-tracing/wtracing"
@@ -32,6 +33,7 @@ func (l *defaultLogger) Log(span wtracing.SpanModel, params ...Param) {
 		append([]wlog.Param{
 			wlog.NewParam(func(entry wlog.LogEntry) {
 				entry.StringValue(wlog.TypeKey, TypeValue)
+				entry.StringValue(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
 				entry.ObjectValue(SpanKey, span, spanType)
 			}),
 		}, l.toParams(params)...)...,


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Time, Level, and Message keys are added by default in the logger provider. This means the provider won't work for logger like wrapped.1 logger in https://github.com/palantir/witchcraft-go-logging/pull/119 that do not specify these keys.

Loggers that require these keys now specify them using params.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
remove time, level, and message keys in logger provider
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
This would be a break to downstream consumers of the logger provider who relied on the presence of these keys by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/123)
<!-- Reviewable:end -->
