### PR TITLE
fix: async writer: Drop logs if buffer is full

### DIFF
--- a/changelog/@unreleased/pr-135.v2.yml
+++ b/changelog/@unreleased/pr-135.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'Async writer: Drop logs if buffer is full'
+  links:
+  - https://github.com/palantir/witchcraft-go-logging/pull/135

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/nmiyake/pkg/dirs v1.0.0
+	github.com/palantir/go-metrics v1.1.0
 	github.com/palantir/pkg/datetime v1.0.1
 	github.com/palantir/pkg/metrics v1.0.1
 	github.com/palantir/pkg/objmatcher v1.0.1

--- a/wlog/tcpjson/async_writer.go
+++ b/wlog/tcpjson/async_writer.go
@@ -18,26 +18,30 @@ import (
 	"io"
 	"log"
 
+	gometrics "github.com/palantir/go-metrics"
 	"github.com/palantir/pkg/metrics"
 	werror "github.com/palantir/witchcraft-go-error"
 )
 
 const (
 	// asyncWriterBufferCap is an arbitrarily high limit for the number of messages allowed to queue before writes will block.
-	asyncWriterBufferCapacity = 1000
+	asyncWriterBufferCapacity = 15000
 	asyncWriterBufferLenGauge = "logging.queue"
+	asyncWriterDroppedCounter = "logging.queue.dropped"
 )
 
 type asyncWriter struct {
-	buffer chan []byte
-	output io.Writer
-	stop   chan struct{}
+	buffer  chan []byte
+	output  io.Writer
+	dropped gometrics.Counter
+	stop    chan struct{}
 }
 
 // StartAsyncWriter creates a Writer whose Write method puts the submitted byte slice onto a channel.
 // In a separate goroutine, slices are pulled from the queue and written to the output writer.
 // The Close method stops the consumer goroutine and will cause future writes to fail.
 func StartAsyncWriter(output io.Writer, registry metrics.Registry) io.WriteCloser {
+	droppedCounter := registry.Counter(asyncWriterDroppedCounter)
 	buffer := make(chan []byte, asyncWriterBufferCapacity)
 	stop := make(chan struct{})
 	go func() {
@@ -45,17 +49,18 @@ func StartAsyncWriter(output io.Writer, registry metrics.Registry) io.WriteClose
 		for {
 			select {
 			case item := <-buffer:
+				gauge.Update(int64(len(buffer)))
 				if _, err := output.Write(item); err != nil {
 					// TODO(bmoylan): consider re-enqueuing message so it can be attempted again, which risks a thundering herd without careful handling.
 					log.Printf("write failed: %s", werror.GenerateErrorString(err, false))
+					droppedCounter.Inc(1)
 				}
-				gauge.Update(int64(len(buffer)))
 			case <-stop:
 				return
 			}
 		}
 	}()
-	return &asyncWriter{buffer: buffer, output: output, stop: stop}
+	return &asyncWriter{buffer: buffer, output: output, dropped: droppedCounter, stop: stop}
 }
 
 func (w *asyncWriter) Write(b []byte) (int, error) {
@@ -67,7 +72,12 @@ func (w *asyncWriter) Write(b []byte) (int, error) {
 		// byte slice is not retained and thus still compliant with the io.Writer contract
 		bb := make([]byte, len(b))
 		copy(bb, b)
-		w.buffer <- bb
+		select {
+		case w.buffer <- bb:
+		default:
+			// drop logs -- nothing we can do
+			w.dropped.Inc(1)
+		}
 		return len(b), nil
 	}
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/135)
<!-- Reviewable:end -->
