### PR TITLE
improvement: Add Drain() method to tcpjson.AsyncWriter

### DIFF
--- a/changelog/@unreleased/pr-142.v2.yml
+++ b/changelog/@unreleased/pr-142.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add Drain() method to tcpjson.AsyncWriter
+  links:
+  - https://github.com/palantir/witchcraft-go-logging/pull/142

--- a/wlog/tcpjson/async_writer.go
+++ b/wlog/tcpjson/async_writer.go
@@ -42,7 +42,7 @@ type asyncWriter struct {
 type AsyncWriter interface {
 	io.WriteCloser
 	// Drain tries to gracefully drain the remaining buffered messages,
-	//  blocking until the buffer is empty or the provided context is cancelled.
+	// blocking until the buffer is empty or the provided context is cancelled.
 	Drain(ctx context.Context)
 }
 

--- a/wlog/tcpjson/async_writer.go
+++ b/wlog/tcpjson/async_writer.go
@@ -57,11 +57,14 @@ func StartAsyncWriter(output io.Writer, registry metrics.Registry) AsyncWriter {
 	w := &asyncWriter{buffer: buffer, output: output, dropped: droppedCounter, queued: queued, stop: stop}
 	go func() {
 		for {
+			// Ensure we stop when requested. Without the additional select,
+			// the loop could continue to run as long as there are items in the buffer.
 			select {
 			case <-stop:
 				return
 			default:
 			}
+
 			select {
 			case item := <-buffer:
 				w.write(item)

--- a/wlog/tcpjson/async_writer.go
+++ b/wlog/tcpjson/async_writer.go
@@ -15,6 +15,7 @@
 package tcpjson
 
 import (
+	"context"
 	"io"
 	"log"
 
@@ -34,33 +35,51 @@ type asyncWriter struct {
 	buffer  chan []byte
 	output  io.Writer
 	dropped gometrics.Counter
+	queued  gometrics.Gauge
 	stop    chan struct{}
+}
+
+type AsyncWriter interface {
+	io.WriteCloser
+	// Drain tries to gracefully drain the remaining buffered messages,
+	//  blocking until the buffer is empty or the provided context is cancelled.
+	Drain(ctx context.Context)
 }
 
 // StartAsyncWriter creates a Writer whose Write method puts the submitted byte slice onto a channel.
 // In a separate goroutine, slices are pulled from the queue and written to the output writer.
 // The Close method stops the consumer goroutine and will cause future writes to fail.
-func StartAsyncWriter(output io.Writer, registry metrics.Registry) io.WriteCloser {
+func StartAsyncWriter(output io.Writer, registry metrics.Registry) AsyncWriter {
 	droppedCounter := registry.Counter(asyncWriterDroppedCounter)
 	buffer := make(chan []byte, asyncWriterBufferCapacity)
 	stop := make(chan struct{})
+	queued := registry.Gauge(asyncWriterBufferLenGauge)
+	w := &asyncWriter{buffer: buffer, output: output, dropped: droppedCounter, queued: queued, stop: stop}
 	go func() {
-		gauge := registry.Gauge(asyncWriterBufferLenGauge)
 		for {
 			select {
+			case <-stop:
+				return
+			default:
+			}
+			select {
 			case item := <-buffer:
-				gauge.Update(int64(len(buffer)))
-				if _, err := output.Write(item); err != nil {
-					// TODO(bmoylan): consider re-enqueuing message so it can be attempted again, which risks a thundering herd without careful handling.
-					log.Printf("write failed: %s", werror.GenerateErrorString(err, false))
-					droppedCounter.Inc(1)
-				}
+				w.write(item)
 			case <-stop:
 				return
 			}
 		}
 	}()
-	return &asyncWriter{buffer: buffer, output: output, dropped: droppedCounter, stop: stop}
+	return w
+}
+
+func (w *asyncWriter) write(item []byte) {
+	w.queued.Update(int64(len(w.buffer)))
+	if _, err := w.output.Write(item); err != nil {
+		// TODO(bmoylan): consider re-enqueuing message so it can be attempted again, which risks a thundering herd without careful handling.
+		log.Printf("write failed: %s", werror.GenerateErrorString(err, false))
+		w.dropped.Inc(1)
+	}
 }
 
 func (w *asyncWriter) Write(b []byte) (int, error) {
@@ -86,4 +105,18 @@ func (w *asyncWriter) Write(b []byte) (int, error) {
 func (w *asyncWriter) Close() (err error) {
 	close(w.stop)
 	return nil
+}
+
+func (w *asyncWriter) Drain(ctx context.Context) {
+	for {
+		select {
+		case item := <-w.buffer:
+			w.write(item)
+		case <-ctx.Done():
+			return
+		default:
+			// Nothing left in the buffer, time to return
+			return
+		}
+	}
 }


### PR DESCRIPTION
This will get used during a process's shutdown when it wants to ensure that all logs have been sent to the TCP receiver.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/142)
<!-- Reviewable:end -->
