### PR TITLE
Update witchcraft-logging-api Conjure definition to v1.3.0

### DIFF
--- a/changelog/@unreleased/pr-145.v2.yml
+++ b/changelog/@unreleased/pr-145.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Updates Conjure definition for witchcraft-logging-api to v1.3.0
+  links:
+  - https://github.com/palantir/witchcraft-go-logging/pull/145

--- a/conjure/witchcraft/api/logging/aliases.conjure.go
+++ b/conjure/witchcraft/api/logging/aliases.conjure.go
@@ -2,7 +2,7 @@
 
 package logging
 
-type TraceId string
 type SessionId string
 type TokenId string
+type TraceId string
 type UserId string

--- a/godel/config/conjure-plugin.yml
+++ b/godel/config/conjure-plugin.yml
@@ -2,4 +2,4 @@ version: 1
 projects:
   conjure:
     output-dir: ./conjure
-    ir-locator: https://palantir.bintray.com/releases/com/palantir/witchcraft/api/witchcraft-logging-api/1.0.0/witchcraft-logging-api-1.0.0.conjure.json
+    ir-locator: https://repo1.maven.org/maven2/com/palantir/witchcraft/api/witchcraft-logging-api/1.3.0/witchcraft-logging-api-1.3.0.conjure.json


### PR DESCRIPTION
Use Maven for IR locator rather than Bintray.

## Before this PR
IR locator for Conjure definition uses Bintray, which is being shut down.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates Conjure definition for witchcraft-logging-api to v1.3.0
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/145)
<!-- Reviewable:end -->
