### PR TITLE
Add logs for WithLoggerParams functionality to audit logs 

### DIFF
--- a/changelog/@unreleased/pr-297.v2.yml
+++ b/changelog/@unreleased/pr-297.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+feature:
+  description: Add logs for WithLoggerParams functionality to audit logs
+  links:
+    - https://github.com/palantir/witchcraft-go-logging/pull/297

--- a/wlog/auditlog/audit2log/context.go
+++ b/wlog/auditlog/audit2log/context.go
@@ -23,10 +23,7 @@ import (
 
 type audit2LogContextKeyType string
 
-const (
-	contextKey = audit2LogContextKeyType(TypeValue)
-	ParamsKey  = "params"
-)
+const contextKey = audit2LogContextKeyType(TypeValue)
 
 // WithLogger returns a copy of the provided context with the provided Logger included as a value. This operation will
 // replace any logger that was previously set on the context (along with all parameters that may have been set on the

--- a/wlog/auditlog/audit2log/context.go
+++ b/wlog/auditlog/audit2log/context.go
@@ -17,19 +17,40 @@ package audit2log
 import (
 	"context"
 
+	"github.com/palantir/witchcraft-go-logging/wlog"
 	wloginternal "github.com/palantir/witchcraft-go-logging/wlog/internal"
+	wparams "github.com/palantir/witchcraft-go-params"
 	"github.com/palantir/witchcraft-go-tracing/wtracing"
 )
 
 type audit2LogContextKeyType string
 
-const contextKey = audit2LogContextKeyType(TypeValue)
+const (
+	contextKey = audit2LogContextKeyType(TypeValue)
+	ParamsKey  = "params"
+)
 
 // WithLogger returns a copy of the provided context with the provided Logger included as a value. This operation will
 // replace any logger that was previously set on the context (along with all parameters that may have been set on the
 // logger).
 func WithLogger(ctx context.Context, logger Logger) context.Context {
 	return context.WithValue(ctx, contextKey, logger)
+}
+
+// WithLoggerParams returns a copy of the provided context whose logger is configured with the provided parameters. If
+// no parameters are provided, the original context is returned unmodified. If the provided context did not have a
+// logger set on it, the returned context will contain the default logger configured with the provided parameters. If
+// any of the provided parameters set safe or unsafe values, the returned context will also have those values set on it
+// using the wparams.ContextWithSafeAndUnsafeParams function.
+func WithLoggerParams(ctx context.Context, params ...Param) context.Context {
+	if len(params) == 0 {
+		return ctx
+	}
+	// if the provided params set any safe or unsafe values, set those as wparams on the context
+	if safeParams, unsafeParams := safeAndUnsafeParamsFromParams(params); len(safeParams) > 0 || len(unsafeParams) > 0 {
+		ctx = wparams.ContextWithSafeAndUnsafeParams(ctx, safeParams, unsafeParams)
+	}
+	return WithLogger(ctx, WithParams(loggerFromContext(ctx), params...))
 }
 
 // FromContext returns the Logger stored in the provided context. If no logger is set on the context, returns the logger
@@ -51,6 +72,14 @@ func FromContext(ctx context.Context) Logger {
 		params = append(params, TraceID(string(traceID)))
 	}
 	return WithParams(logger, params...)
+}
+
+func safeAndUnsafeParamsFromParams(params []Param) (safe map[string]interface{}, unsafe map[string]interface{}) {
+	logEntry := wlog.NewMapLogEntry()
+	for _, currParam := range params {
+		currParam.apply(logEntry)
+	}
+	return logEntry.AnyMapValues()[ParamsKey], logEntry.AnyMapValues()[wlog.UnsafeParamsKey]
 }
 
 // loggerFromContext returns the logger stored in the provided context. If no logger is set on the context, returns the

--- a/wlog/auditlog/audit2log/context.go
+++ b/wlog/auditlog/audit2log/context.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/palantir/witchcraft-go-logging/wlog"
 	wloginternal "github.com/palantir/witchcraft-go-logging/wlog/internal"
-	wparams "github.com/palantir/witchcraft-go-params"
 	"github.com/palantir/witchcraft-go-tracing/wtracing"
 )
 
@@ -39,16 +38,10 @@ func WithLogger(ctx context.Context, logger Logger) context.Context {
 
 // WithLoggerParams returns a copy of the provided context whose logger is configured with the provided parameters. If
 // no parameters are provided, the original context is returned unmodified. If the provided context did not have a
-// logger set on it, the returned context will contain the default logger configured with the provided parameters. If
-// any of the provided parameters set safe or unsafe values, the returned context will also have those values set on it
-// using the wparams.ContextWithSafeAndUnsafeParams function.
+// logger set on it, the returned context will contain the default logger configured with the provided parameters.
 func WithLoggerParams(ctx context.Context, params ...Param) context.Context {
 	if len(params) == 0 {
 		return ctx
-	}
-	// if the provided params set any safe or unsafe values, set those as wparams on the context
-	if safeParams, unsafeParams := safeAndUnsafeParamsFromParams(params); len(safeParams) > 0 || len(unsafeParams) > 0 {
-		ctx = wparams.ContextWithSafeAndUnsafeParams(ctx, safeParams, unsafeParams)
 	}
 	return WithLogger(ctx, WithParams(loggerFromContext(ctx), params...))
 }

--- a/wlog/auditlog/audit2log/context.go
+++ b/wlog/auditlog/audit2log/context.go
@@ -17,7 +17,6 @@ package audit2log
 import (
 	"context"
 
-	"github.com/palantir/witchcraft-go-logging/wlog"
 	wloginternal "github.com/palantir/witchcraft-go-logging/wlog/internal"
 	"github.com/palantir/witchcraft-go-tracing/wtracing"
 )
@@ -65,14 +64,6 @@ func FromContext(ctx context.Context) Logger {
 		params = append(params, TraceID(string(traceID)))
 	}
 	return WithParams(logger, params...)
-}
-
-func safeAndUnsafeParamsFromParams(params []Param) (safe map[string]interface{}, unsafe map[string]interface{}) {
-	logEntry := wlog.NewMapLogEntry()
-	for _, currParam := range params {
-		currParam.apply(logEntry)
-	}
-	return logEntry.AnyMapValues()[ParamsKey], logEntry.AnyMapValues()[wlog.UnsafeParamsKey]
 }
 
 // loggerFromContext returns the logger stored in the provided context. If no logger is set on the context, returns the

--- a/wlog/auditlog/audit2log/params.go
+++ b/wlog/auditlog/audit2log/params.go
@@ -112,3 +112,27 @@ func ResultParams(resultParams map[string]interface{}) Param {
 		entry.AnyMapValue(ResultParamsKey, resultParams)
 	})
 }
+
+func SafeParam(key string, value interface{}) Param {
+	return SafeParams(map[string]interface{}{
+		key: value,
+	})
+}
+
+func SafeParams(safe map[string]interface{}) Param {
+	return paramFunc(func(entry wlog.LogEntry) {
+		entry.AnyMapValue(ParamsKey, safe)
+	})
+}
+
+func UnsafeParam(key string, value interface{}) Param {
+	return UnsafeParams(map[string]interface{}{
+		key: value,
+	})
+}
+
+func UnsafeParams(unsafe map[string]interface{}) Param {
+	return paramFunc(func(entry wlog.LogEntry) {
+		entry.AnyMapValue(wlog.UnsafeParamsKey, unsafe)
+	})
+}

--- a/wlog/auditlog/audit2log/params.go
+++ b/wlog/auditlog/audit2log/params.go
@@ -112,27 +112,3 @@ func ResultParams(resultParams map[string]interface{}) Param {
 		entry.AnyMapValue(ResultParamsKey, resultParams)
 	})
 }
-
-func SafeParam(key string, value interface{}) Param {
-	return SafeParams(map[string]interface{}{
-		key: value,
-	})
-}
-
-func SafeParams(safe map[string]interface{}) Param {
-	return paramFunc(func(entry wlog.LogEntry) {
-		entry.AnyMapValue(ParamsKey, safe)
-	})
-}
-
-func UnsafeParam(key string, value interface{}) Param {
-	return UnsafeParams(map[string]interface{}{
-		key: value,
-	})
-}
-
-func UnsafeParams(unsafe map[string]interface{}) Param {
-	return paramFunc(func(entry wlog.LogEntry) {
-		entry.AnyMapValue(wlog.UnsafeParamsKey, unsafe)
-	})
-}


### PR DESCRIPTION
## Before this PR
The audit logs currently do not support hydrating the context with params. This can be helpful if we want to augment the context with more info (coming from the request or otherwise). This functionality is already available with the service logs (`svclog`).

## After this PR
==COMMIT_MSG==
Allows clients to use `WithLoggerParams` to hydrate contexts with params as needed
==COMMIT_MSG==

## Tests
Unit tests added to test for the specific functionality, tried to maintain parity with `svclog` tests

