### PR TITLE
fix changelog for pr-297

### DIFF
--- a/changelog/@unreleased/pr-297.v2.yml
+++ b/changelog/@unreleased/pr-297.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
-feature:
+improvement:
   description: Add logs for WithLoggerParams functionality to audit logs
   links:
     - https://github.com/palantir/witchcraft-go-logging/pull/297


### PR DESCRIPTION
## Before this PR
Auto release will be blocked due to a typo in changelog. This PR fixes the cl.