### PR TITLE
improvement: wapp: Format thread dumps and panics in the 'stacktrace' service log field

### DIFF
--- a/changelog/@unreleased/pr-352.v2.yml
+++ b/changelog/@unreleased/pr-352.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: 'Wapp: Format thread dumps and panics in the ''stacktrace'' service
+    log field'
+  links:
+  - https://github.com/palantir/witchcraft-go-logging/pull/352

--- a/wlog/diaglog/diag1log/thread_dump.go
+++ b/wlog/diaglog/diag1log/thread_dump.go
@@ -38,6 +38,40 @@ func ThreadDumpV1FromGoroutines(goroutinesContent []byte) logging.ThreadDumpV1 {
 	return threads
 }
 
+func ThreadDumpV1ToGoroutines(threads logging.ThreadDumpV1) string {
+	var out strings.Builder
+	for _, thread := range threads.Threads {
+		if thread.Name != nil {
+			out.WriteString(*thread.Name)
+			out.WriteString(":\n")
+		}
+		for _, frame := range thread.StackTrace {
+			if frame.Procedure != nil {
+				if frame.Params["goroutineCreator"] == true {
+					out.WriteString("created by ")
+				}
+				out.WriteString(*frame.Procedure)
+				out.WriteString("(...)\n")
+			}
+			if frame.File != nil {
+				out.WriteByte('\t')
+				out.WriteString(*frame.File)
+				if frame.Line != nil {
+					out.WriteByte(':')
+					out.WriteString(strconv.Itoa(*frame.Line))
+				}
+				if frame.Address != nil {
+					out.WriteString(" +")
+					out.WriteString(*frame.Address)
+				}
+				out.WriteByte('\n')
+			}
+
+		}
+	}
+	return out.String()
+}
+
 var titleLinePattern = regexp.MustCompile(`^(goroutine (\d+) \[([^]]+)]):$`)
 
 func unmarshalThreadDump(goroutine []byte) logging.ThreadInfoV1 {

--- a/wlog/diaglog/diag1log/thread_dump_test.go
+++ b/wlog/diaglog/diag1log/thread_dump_test.go
@@ -25,9 +25,10 @@ import (
 
 func TestThreadDumpV1FromGoroutines(t *testing.T) {
 	for _, test := range []struct {
-		Name     string
-		Input    string
-		Expected logging.ThreadDumpV1
+		Name      string
+		Input     string
+		Marshaled string
+		Expected  logging.ThreadDumpV1
 	}{
 		{
 			Name: "single goroutine",
@@ -36,6 +37,12 @@ net/http.(*persistConn).writeLoop(0xc0000bd0e0)
 	/usr/local/Cellar/go/1.11.2/libexec/src/net/http/transport.go:1885 +0x113
 created by net/http.(*Transport).dialConn
 	/usr/local/Cellar/go/1.11.2/libexec/src/net/http/transport.go:1339 +0x966
+`,
+			Marshaled: `goroutine 14 [select]:
+net/http.(*persistConn).writeLoop(...)
+	net/http/transport.go:1885 +0x113
+created by net/http.(*Transport).dialConn(...)
+	net/http/transport.go:1339 +0x966
 `,
 			Expected: logging.ThreadDumpV1{
 				Threads: []logging.ThreadInfoV1{
@@ -73,6 +80,11 @@ net/http.(*persistConn).writeLoop(0xc0000bd0e0)
 created by net/http.(*Transport).dialConn
 	/usr/local/Cellar/go/1.11.2/libexec/src/net/http/transport.go +0x966
 `,
+			Marshaled: `goroutine 14 [select]:
+net/http.(*persistConn).writeLoop(...)
+	net/http/transport.go:1885
+created by net/http.(*Transport).dialConn(...)
+`,
 			Expected: logging.ThreadDumpV1{
 				Threads: []logging.ThreadInfoV1{
 					{
@@ -105,6 +117,8 @@ created by net/http.(*Transport).dialConn
 		t.Run(test.Name, func(t *testing.T) {
 			dump := diag1log.ThreadDumpV1FromGoroutines([]byte(test.Input))
 			require.Equal(t, test.Expected, dump)
+			out := diag1log.ThreadDumpV1ToGoroutines(dump)
+			require.Equal(t, test.Marshaled, out)
 		})
 	}
 }

--- a/wlog/logentry.go
+++ b/wlog/logentry.go
@@ -82,9 +82,6 @@ func (m *MapValueEntries) AnyMapValue(key string, values map[string]interface{})
 	if len(values) == 0 {
 		return
 	}
-	if len(values) == 0 {
-		return
-	}
 	if m.anyMapValues == nil {
 		m.anyMapValues = make(map[string]map[string]interface{})
 	}

--- a/wlog/wapp/fatal_test.go
+++ b/wlog/wapp/fatal_test.go
@@ -152,7 +152,7 @@ github\.com/palantir/witchcraft-go-logging/wlog/wapp_test\.TestRunWithRecoveryLo
 	github\.com/palantir/witchcraft-go-logging/wlog/wapp/fatal_test\.go:\d+ \+0x[0-9a-f]+
 testing\.tRunner\(\.\.\.\)
 	testing/testing\.go:\d+ \+0x[0-9a-f]+
-created by testing\.\(\*T\)\.Run in goroutine \d+\(\.\.\.\)
+created by testing\.\(\*T\)\.Run( in goroutine \d+\(\.\.\.\))?
 	testing/testing\.go:\d+ \+0x[0-9a-f]+
 `)
 		assert.Regexp(t, p.String(), *msg.Stacktrace)

--- a/wlog/wapp/fatal_test.go
+++ b/wlog/wapp/fatal_test.go
@@ -152,7 +152,7 @@ github\.com/palantir/witchcraft-go-logging/wlog/wapp_test\.TestRunWithRecoveryLo
 	github\.com/palantir/witchcraft-go-logging/wlog/wapp/fatal_test\.go:\d+ \+0x[0-9a-f]+
 testing\.tRunner\(\.\.\.\)
 	testing/testing\.go:\d+ \+0x[0-9a-f]+
-created by testing\.\(\*T\)\.Run( in goroutine \d+\(\.\.\.\))?
+created by testing\.\(\*T\)\.Run( in goroutine \d+)?\(\.\.\.\)
 	testing/testing\.go:\d+ \+0x[0-9a-f]+
 `)
 		assert.Regexp(t, p.String(), *msg.Stacktrace)


### PR DESCRIPTION
The current SafeParam `"stacktrace"` is a deeply nested JSON structure. For usability's sake, we can format this in a more familiar way where we normally put the `werror`-based stacktrace.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-logging/352)
<!-- Reviewable:end -->
