### PR TITLE
Refactor audit2log to use shared internal package

### DIFF
--- a/changelog/@unreleased/pr-399.v2.yml
+++ b/changelog/@unreleased/pr-399.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Updates implementation of audit2log package to use an internal package.
+  links:
+  - https://github.com/palantir/witchcraft-go-logging/pull/399

--- a/wlog/auditlog/audit2log/logger.go
+++ b/wlog/auditlog/audit2log/logger.go
@@ -18,18 +18,33 @@ import (
 	"io"
 
 	"github.com/palantir/witchcraft-go-logging/wlog"
+	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/internal/auditloginternal"
 )
 
 type AuditResultType string
 
 const (
-	AuditResultSuccess      AuditResultType = "SUCCESS"
-	AuditResultUnauthorized AuditResultType = "UNAUTHORIZED"
-	AuditResultError        AuditResultType = "ERROR"
+	AuditResultSuccess      = AuditResultType(auditloginternal.AuditResultSuccess)
+	AuditResultUnauthorized = AuditResultType(auditloginternal.AuditResultUnauthorized)
+	AuditResultError        = AuditResultType(auditloginternal.AuditResultError)
 )
 
 type Logger interface {
 	Audit(name string, result AuditResultType, params ...Param)
+}
+
+type audit2LoggerAdapter struct {
+	audit2logger auditloginternal.Audit2Logger
+}
+
+func (a *audit2LoggerAdapter) Audit(name string, result AuditResultType, params ...Param) {
+	a.audit2logger.Audit(name, auditloginternal.AuditResultType(result), convertExternalParamsToInternalParams(params)...)
+}
+
+func convertInternalLoggerToExternalLogger(logger auditloginternal.Audit2Logger) Logger {
+	return &audit2LoggerAdapter{
+		audit2logger: logger,
+	}
 }
 
 func New(w io.Writer) Logger {
@@ -37,9 +52,7 @@ func New(w io.Writer) Logger {
 }
 
 func NewFromCreator(w io.Writer, creator wlog.LoggerCreator) Logger {
-	return &defaultLogger{
-		logger: creator(w),
-	}
+	return convertInternalLoggerToExternalLogger(auditloginternal.Audit2NewFromCreator(w, creator))
 }
 
 func WithParams(logger Logger, params ...Param) Logger {

--- a/wlog/auditlog/audit2log/params.go
+++ b/wlog/auditlog/audit2log/params.go
@@ -16,105 +16,100 @@ package audit2log
 
 import (
 	"github.com/palantir/witchcraft-go-logging/wlog"
+	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/internal/auditloginternal"
 )
 
 const (
-	TypeValue = "audit.2"
+	TypeValue = auditloginternal.Audit2TypeValue
 
-	OtherUIDsKey     = "otherUids"
-	OriginKey        = "origin"
-	NameKey          = "name"
-	ResultKey        = "result"
-	RequestParamsKey = "requestParams"
-	ResultParamsKey  = "resultParams"
+	OtherUIDsKey     = auditloginternal.Audit2OtherUIDsKey
+	OriginKey        = auditloginternal.Audit2OriginKey
+	NameKey          = auditloginternal.Audit2NameKey
+	ResultKey        = auditloginternal.Audit2ResultKey
+	RequestParamsKey = auditloginternal.Audit2RequestParamsKey
+	ResultParamsKey  = auditloginternal.Audit2ResultParamsKey
 )
 
 type Param interface {
-	apply(entry wlog.LogEntry)
+	getParam() auditloginternal.AuditParam
+}
+
+var _ Param = (*paramStruct)(nil)
+
+type paramStruct struct {
+	param auditloginternal.Audit2Param
+}
+
+func (p *paramStruct) getParam() auditloginternal.AuditParam {
+	return p.param.Param
 }
 
 func ApplyParam(p Param, entry wlog.LogEntry) {
 	if p == nil {
 		return
 	}
-	p.apply(entry)
+	p.getParam().Audit2ParamFn(entry)
 }
 
-type paramFunc func(entry wlog.LogEntry)
-
-func (f paramFunc) apply(entry wlog.LogEntry) {
-	f(entry)
+func convertInternalParamToExportedParam(param auditloginternal.Audit2Param) Param {
+	return &paramStruct{
+		param: param,
+	}
 }
 
-func auditNameResultParam(name string, resultType AuditResultType) Param {
-	return paramFunc(func(logger wlog.LogEntry) {
-		logger.StringValue(NameKey, name)
-		logger.StringValue(ResultKey, string(resultType))
-	})
+func convertExternalParamsToInternalParams(params []Param) []auditloginternal.Audit2Param {
+	if params == nil {
+		return nil
+	}
+	out := make([]auditloginternal.Audit2Param, len(params))
+	for i, param := range params {
+		out[i] = auditloginternal.Audit2Param{
+			Param: param.getParam(),
+		}
+	}
+	return out
 }
 
 func UID(uid string) Param {
-	return paramFunc(func(entry wlog.LogEntry) {
-		entry.OptionalStringValue(wlog.UIDKey, uid)
-	})
+	return convertInternalParamToExportedParam(auditloginternal.Audit2UID(uid))
 }
 
 func SID(sid string) Param {
-	return paramFunc(func(entry wlog.LogEntry) {
-		entry.OptionalStringValue(wlog.SIDKey, sid)
-	})
+	return convertInternalParamToExportedParam(auditloginternal.Audit2SID(sid))
 }
 
 func TokenID(tokenID string) Param {
-	return paramFunc(func(entry wlog.LogEntry) {
-		entry.OptionalStringValue(wlog.TokenIDKey, tokenID)
-	})
+	return convertInternalParamToExportedParam(auditloginternal.Audit2TokenID(tokenID))
 }
 
 func OrgID(orgID string) Param {
-	return paramFunc(func(entry wlog.LogEntry) {
-		entry.OptionalStringValue(wlog.OrgIDKey, orgID)
-	})
+	return convertInternalParamToExportedParam(auditloginternal.Audit2OrgID(orgID))
 }
 
 func TraceID(traceID string) Param {
-	return paramFunc(func(entry wlog.LogEntry) {
-		entry.OptionalStringValue(wlog.TraceIDKey, traceID)
-	})
+	return convertInternalParamToExportedParam(auditloginternal.Audit2TraceID(traceID))
 }
 
 func OtherUIDs(otherUIDs ...string) Param {
-	return paramFunc(func(entry wlog.LogEntry) {
-		entry.StringListValue(OtherUIDsKey, otherUIDs)
-	})
+	return convertInternalParamToExportedParam(auditloginternal.Audit2OtherUIDs(otherUIDs...))
 }
 
 func Origin(origin string) Param {
-	return paramFunc(func(entry wlog.LogEntry) {
-		entry.OptionalStringValue(OriginKey, origin)
-	})
+	return convertInternalParamToExportedParam(auditloginternal.Audit2Origin(origin))
 }
 
 func RequestParam(key string, value interface{}) Param {
-	return RequestParams(map[string]interface{}{
-		key: value,
-	})
+	return convertInternalParamToExportedParam(auditloginternal.Audit2RequestParam(key, value))
 }
 
 func RequestParams(requestParams map[string]interface{}) Param {
-	return paramFunc(func(entry wlog.LogEntry) {
-		entry.AnyMapValue(RequestParamsKey, requestParams)
-	})
+	return convertInternalParamToExportedParam(auditloginternal.Audit2RequestParams(requestParams))
 }
 
 func ResultParam(key string, value interface{}) Param {
-	return ResultParams(map[string]interface{}{
-		key: value,
-	})
+	return convertInternalParamToExportedParam(auditloginternal.Audit2ResultParam(key, value))
 }
 
 func ResultParams(resultParams map[string]interface{}) Param {
-	return paramFunc(func(entry wlog.LogEntry) {
-		entry.AnyMapValue(ResultParamsKey, resultParams)
-	})
+	return convertInternalParamToExportedParam(auditloginternal.Audit2ResultParams(resultParams))
 }

--- a/wlog/auditlog/internal/auditloginternal/audit2_logger.go
+++ b/wlog/auditlog/internal/auditloginternal/audit2_logger.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package audit2log
+package auditloginternal
 
 import (
+	"io"
+
 	"github.com/palantir/witchcraft-go-logging/wlog"
-	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/internal/auditloginternal"
 )
 
-func ToParams(name string, result AuditResultType, inParams []Param) []wlog.Param {
-	return auditloginternal.Audit2ToParams(name, auditloginternal.AuditResultType(result), convertExternalParamsToInternalParams(inParams))
+type Audit2Logger interface {
+	Audit(name string, result AuditResultType, params ...Audit2Param)
+}
+
+type audit2LoggerImpl struct {
+	logger *logger
+}
+
+func (a *audit2LoggerImpl) Audit(name string, result AuditResultType, params ...Audit2Param) {
+	a.logger.Audit2(name, result, params...)
+}
+
+func Audit2NewFromCreator(audit2Writer io.Writer, creator wlog.LoggerCreator) Audit2Logger {
+	return &audit2LoggerImpl{
+		logger: &logger{
+			audit2Logger: creator(audit2Writer),
+		},
+	}
 }

--- a/wlog/auditlog/internal/auditloginternal/audit2_params.go
+++ b/wlog/auditlog/internal/auditloginternal/audit2_params.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auditloginternal
+
+import (
+	"time"
+
+	"github.com/palantir/witchcraft-go-logging/wlog"
+)
+
+const (
+	Audit2TypeValue = "audit.2"
+
+	Audit2OtherUIDsKey     = "otherUids"
+	Audit2OriginKey        = "origin"
+	Audit2NameKey          = "name"
+	Audit2ResultKey        = "result"
+	Audit2RequestParamsKey = "requestParams"
+	Audit2ResultParamsKey  = "resultParams"
+)
+
+// Audit2Param is effectively a marker type that wraps AuditParam.
+// The AuditParam interface requires specifying outputs for both audit.v2 and audit.v3, but the Audit2Param type should
+// only be used for parameters that are "native" to audit.v2.
+type Audit2Param struct {
+	Param AuditParam
+}
+
+func Audit2ToParams(name string, result AuditResultType, inParams []Audit2Param) []wlog.Param {
+	outParams := make([]wlog.Param, 1+len(inParams))
+	outParams[0] = wlog.NewParam(func(entry wlog.LogEntry) {
+		entry.StringValue(wlog.TypeKey, Audit2TypeValue)
+		entry.StringValue(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
+		auditNameResultParam(name, result).Audit2ParamFn(entry)
+	})
+	for idx := range inParams {
+		outParams[1+idx] = wlog.NewParam(inParams[idx].Param.Audit2ParamFn)
+	}
+	return outParams
+}
+
+func Audit2UID(uid string) Audit2Param {
+	return Audit2Param{
+		Param: uidParam(uid),
+	}
+}
+
+func Audit2SID(sid string) Audit2Param {
+	return Audit2Param{
+		Param: sidParam(sid),
+	}
+}
+
+func Audit2TokenID(tokenID string) Audit2Param {
+	return Audit2Param{
+		Param: tokenIDParam(tokenID),
+	}
+}
+
+func Audit2OrgID(orgID string) Audit2Param {
+	return Audit2Param{
+		Param: orgIDParam(orgID),
+	}
+}
+
+func Audit2TraceID(traceID string) Audit2Param {
+	return Audit2Param{
+		Param: traceIDParam(traceID),
+	}
+}
+
+func Audit2OtherUIDs(otherUIDs ...string) Audit2Param {
+	return Audit2Param{
+		Param: AuditParam{
+			Audit2ParamFn: func(entry wlog.LogEntry) {
+				entry.StringListValue(Audit2OtherUIDsKey, otherUIDs)
+			},
+		},
+	}
+}
+
+func Audit2Origin(origin string) Audit2Param {
+	return Audit2Param{
+		Param: originParam(origin),
+	}
+}
+
+func Audit2RequestParam(key string, value interface{}) Audit2Param {
+	return Audit2RequestParams(map[string]interface{}{
+		key: value,
+	})
+}
+
+func Audit2RequestParams(requestParams map[string]interface{}) Audit2Param {
+	return Audit2Param{
+		Param: AuditParam{
+			Audit2ParamFn: func(entry wlog.LogEntry) {
+				entry.AnyMapValue(Audit2RequestParamsKey, requestParams)
+			},
+		},
+	}
+}
+
+func Audit2ResultParam(key string, value interface{}) Audit2Param {
+	return Audit2ResultParams(map[string]interface{}{
+		key: value,
+	})
+}
+
+func Audit2ResultParams(resultParams map[string]interface{}) Audit2Param {
+	return Audit2Param{
+		Param: AuditParam{
+			Audit2ParamFn: func(entry wlog.LogEntry) {
+				entry.AnyMapValue(Audit2ResultParamsKey, resultParams)
+			},
+		},
+	}
+}

--- a/wlog/auditlog/internal/auditloginternal/logger.go
+++ b/wlog/auditlog/internal/auditloginternal/logger.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package audit2log
+package auditloginternal
 
 import (
 	"github.com/palantir/witchcraft-go-logging/wlog"
-	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/internal/auditloginternal"
 )
 
-func ToParams(name string, result AuditResultType, inParams []Param) []wlog.Param {
-	return auditloginternal.Audit2ToParams(name, auditloginternal.AuditResultType(result), convertExternalParamsToInternalParams(inParams))
+type AuditResultType string
+
+const (
+	AuditResultSuccess      AuditResultType = "SUCCESS"
+	AuditResultUnauthorized AuditResultType = "UNAUTHORIZED"
+	AuditResultError        AuditResultType = "ERROR"
+)
+
+type logger struct {
+	audit2Logger wlog.Logger
+}
+
+func (l *logger) Audit2(name string, result AuditResultType, params ...Audit2Param) {
+	l.audit2Logger.Log(Audit2ToParams(name, result, params)...)
 }

--- a/wlog/auditlog/internal/auditloginternal/params.go
+++ b/wlog/auditlog/internal/auditloginternal/params.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auditloginternal
+
+import (
+	"github.com/palantir/witchcraft-go-logging/wlog"
+)
+
+type AuditParam struct {
+	Audit2ParamFn func(entry wlog.LogEntry)
+}
+
+func auditNameResultParam(name string, resultType AuditResultType) AuditParam {
+	return AuditParam{
+		Audit2ParamFn: func(entry wlog.LogEntry) {
+			entry.StringValue(Audit2NameKey, name)
+			entry.StringValue(Audit2ResultKey, string(resultType))
+		},
+	}
+}
+
+func uidParam(uid string) AuditParam {
+	return sameImplParamFn(func(entry wlog.LogEntry) {
+		entry.OptionalStringValue(wlog.UIDKey, uid)
+	})
+}
+
+func sidParam(sid string) AuditParam {
+	return sameImplParamFn(func(entry wlog.LogEntry) {
+		entry.OptionalStringValue(wlog.SIDKey, sid)
+	})
+}
+
+func tokenIDParam(tokenID string) AuditParam {
+	return sameImplParamFn(func(entry wlog.LogEntry) {
+		entry.OptionalStringValue(wlog.TokenIDKey, tokenID)
+	})
+}
+
+func orgIDParam(orgID string) AuditParam {
+	return sameImplParamFn(func(entry wlog.LogEntry) {
+		entry.OptionalStringValue(wlog.OrgIDKey, orgID)
+	})
+}
+
+func traceIDParam(traceID string) AuditParam {
+	return sameImplParamFn(func(entry wlog.LogEntry) {
+		entry.OptionalStringValue(wlog.TraceIDKey, traceID)
+	})
+}
+
+func originParam(origin string) AuditParam {
+	return AuditParam{
+		Audit2ParamFn: func(entry wlog.LogEntry) {
+			entry.OptionalStringValue(Audit2OriginKey, origin)
+		},
+	}
+}
+
+func sameImplParamFn(fn func(entry wlog.LogEntry)) AuditParam {
+	return AuditParam{
+		Audit2ParamFn: fn,
+	}
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates implementation of audit2log package to use an internal package.
==COMMIT_MSG==

This change should be a noop in terms of functionality and API, but allows for implementing audit.3 logging and supporting dual-writing audit.2 and audit.3 logs.

The primary design change is as follows:
* The underlying logger implementation is moved to the internal package `github.com/palantir/witchcraft-go-logging/wlog/auditlog/internal/auditloginternal`
  * This internal implementation will be updated to support dual-writing for v3
* The internal `github.com/palantir/witchcraft-go-logging/wlog/auditlog/internal/auditloginternal` package defines an `AuditParam` type that will support writing a `wlog` entry for both v2 and v3 for a given conceptual parameter
* The internal `github.com/palantir/witchcraft-go-logging/wlog/auditlog/internal/auditloginternal` also defines a typed `Audit2Param` type that contains an `AuditParam`, but is defined to semantically indicate that the parameter is conceptually an `audit.2` parameter
* All exported types/interfaces are updated such that their underlying implementation uses the new shared private package

This allows for adding `audit.3` and dual-writing capabilities in a follow-up PR in the following manner:

* `audit3log` can be defined as a package analogous to how `audit2log` is defined
* The internal `auditloginternal.AuditParam` struct will add an `Audit3ParamFn` field that defines how the parameter is applied for `audit.3` logs
* The implementations of the existing `Audit2` params are updated to write their `audit.3` equivalents
* The new `Audit3` parameters are typed and have an implementation that writes their `audit.2` equivalents
* The internal shared package allows common logic to be shared
* Logic for creating new `audit.2` and `audit.3` loggers can be expanded to support dual-writing where, if enabled, the parameters provided to an `audit.2` or `audit.3` logger can be applied to the other type of logger as well and written out

This relies on a constraint that every `audit.2` and `audit.3` param can dual-write (or not write) its own value to the other version of audit, but this is the case, so is safe to do.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

