### PR TITLE
Update LogEntry API

### DIFF
--- a/changelog/@unreleased/pr-415.v2.yml
+++ b/changelog/@unreleased/pr-415.v2.yml
@@ -1,0 +1,43 @@
+type: improvement
+improvement:
+  description: |-
+    Updates the LogEntry API by clarifying the semantics/behavior of
+    calls that operate on the same key as previous calls and updates
+    implementations to match the specified behavior.
+
+    The updated API clarifies that a call to any function will result
+    in the specified key being set and overwriting any previous value
+    associated with the key (with the narrow exception of "*MapValue"
+    functions, which will merge/add values if the existing value for
+    the key was set by the same function).
+
+    Also adds a test suite that verifies the wlog behavior and runs
+    the test suite for the zap and zerolog implementations.
+
+    The updated API changes existing behavior as follows:
+    * Previously, calling "OptionalStringValue" with an empty value
+      was a noop. This meant that, if the provided key already had a
+      value associated with it, it would continue to be associated with it.
+      The API contract and behavior has been updated such that the behavior is
+      to remove the value for the key instead.
+    * Previously, calling "StringListValue" with a nil or empty slice
+      was a noop. This meant that, if the provided key already had a
+      value associated with it, it would continue to be associated with it.
+      The API contract and behavior has been updated such that the behavior is
+      to set the value to an empty slice instead.
+    * Previously, implementations had inconsistent/confusing behavior if the
+      same key was set using "StringMapValue", "AnyMapValue", and another setter.
+      In a scenario where a key was set using all 3 functions, the previous implementation
+      would always log the value for "AnyMapValue", regardless of the order in which the
+      calls were made. This ambiguity has been removed by specifying sensible behavior
+      at the interface API level and ensuring that all implementations adhere to it.
+
+    Updating the API contract and implementation also allowed the zerolog
+    implementation to be simplified: previously, the zerolog logger implementation
+    tracked Param inputs and applied them in reverse, which worked, but was confusing
+    and introduced implicit behavioral assumptions between packages. With the LogEntry
+    API updates, the zerolog logger implementation has been updated to be more straightforward.
+
+    This change also uses generics to reduce code duplication.
+  links:
+  - https://github.com/palantir/witchcraft-go-logging/pull/415

--- a/wlog-zap/internal/logger.go
+++ b/wlog-zap/internal/logger.go
@@ -25,9 +25,11 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+var _ wlog.LogEntry = (*zapLogEntry)(nil)
+
 type zapLogEntry struct {
-	fields map[string]*zapcore.Field
-	wlog.MapValueEntries
+	fields          map[string]*zapcore.Field
+	mapValueEntries wlog.MapValueEntries
 }
 
 func newZapLogEntry() *zapLogEntry {
@@ -36,77 +38,100 @@ func newZapLogEntry() *zapLogEntry {
 	}
 }
 
-func (e *zapLogEntry) StringValue(key, value string) {
-	s := zap.String(key, value)
-	e.fields[key] = &s
+func zapLogEntrySetValue[ValT any](entry *zapLogEntry, fn func(k string, v ValT) zap.Field, k string, v ValT) {
+	entry.delete(k)
+	field := fn(k, v)
+	entry.fields[k] = &field
 }
 
-func (e *zapLogEntry) OptionalStringValue(key, value string) {
-	if value != "" {
-		e.StringValue(key, value)
+func (e *zapLogEntry) delete(k string) {
+	delete(e.fields, k)
+	e.mapValueEntries.Delete(k)
+}
+
+func (e *zapLogEntry) StringValue(k, v string) {
+	zapLogEntrySetValue(e, zap.String, k, v)
+}
+
+func (e *zapLogEntry) OptionalStringValue(k, v string) {
+	if v == "" {
+		e.delete(k)
+	} else {
+		e.StringValue(k, v)
 	}
 }
 
 func (e *zapLogEntry) StringListValue(k string, v []string) {
-	if len(v) > 0 {
-		s := zap.Strings(k, v)
-		e.fields[k] = &s
+	if v == nil {
+		v = make([]string, 0)
 	}
+	zapLogEntrySetValue(e, zap.Strings, k, v)
 }
 
-func (e *zapLogEntry) SafeLongValue(key string, value int64) {
-	s := zap.Int64(key, value)
-	e.fields[key] = &s
+func (e *zapLogEntry) SafeLongValue(k string, v int64) {
+	zapLogEntrySetValue(e, zap.Int64, k, v)
 }
 
-func (e *zapLogEntry) IntValue(key string, value int32) {
-	s := zap.Int32(key, value)
-	e.fields[key] = &s
+func (e *zapLogEntry) IntValue(k string, v int32) {
+	zapLogEntrySetValue(e, zap.Int32, k, v)
+}
+
+func (e *zapLogEntry) StringMapValue(k string, v map[string]string) {
+	delete(e.fields, k)
+	e.mapValueEntries.StringMapValue(k, v)
+}
+
+func (e *zapLogEntry) AnyMapValue(k string, v map[string]any) {
+	delete(e.fields, k)
+	e.mapValueEntries.AnyMapValue(k, v)
 }
 
 func (e *zapLogEntry) ObjectValue(k string, v interface{}, marshalerType reflect.Type) {
-	s := zap.Reflect(k, v)
-	e.fields[k] = &s
+	zapLogEntrySetValue(e, zap.Reflect, k, v)
 }
 
 func (e *zapLogEntry) Fields() []zapcore.Field {
-	stringMapValues := e.StringMapValues()
-	anyMapValues := e.AnyMapValues()
+	stringMapValues := e.mapValueEntries.StringMapValues()
+	anyMapValues := e.mapValueEntries.AnyMapValues()
 	fields := make([]zapcore.Field, 0, len(e.fields)+len(stringMapValues)+len(anyMapValues))
 	for _, field := range e.fields {
 		fields = append(fields, *field)
 	}
-	for key, values := range stringMapValues {
-		key := key
-		values := values
-		fields = append(fields, zap.Object(key, zapcore.ObjectMarshalerFunc(func(enc zapcore.ObjectEncoder) error {
-			keys := make([]string, 0, len(values))
-			for k := range values {
-				keys = append(keys, k)
-			}
-			sort.Strings(keys)
-			for _, k := range keys {
-				enc.AddString(k, values[k])
-			}
-			return nil
-		})))
-	}
-	for key, values := range anyMapValues {
-		key := key
-		values := values
-		fields = append(fields, zap.Object(key, zapcore.ObjectMarshalerFunc(func(enc zapcore.ObjectEncoder) error {
-			keys := make([]string, 0, len(values))
-			for k := range values {
-				keys = append(keys, k)
-			}
-			sort.Strings(keys)
-			for _, k := range keys {
-				if err := encodeField(k, values[k], enc); err != nil {
-					return fmt.Errorf("failed to encode field %s: %v", k, err)
+	fields = append(fields, zapLogEntryMapValuesToFields(stringMapValues, func(k string, v string, enc zapcore.ObjectEncoder) error {
+		enc.AddString(k, v)
+		return nil
+	})...)
+	fields = append(fields, zapLogEntryMapValuesToFields(anyMapValues, func(k string, v any, enc zapcore.ObjectEncoder) error {
+		if err := encodeField(k, v, enc); err != nil {
+			return fmt.Errorf("failed to encode field %s: %v", k, err)
+		}
+		return nil
+	})...)
+	return fields
+}
+
+func zapLogEntryMapValuesToFields[ValType any](inputMap map[string]map[string]ValType, valFn func(k string, v ValType, enc zapcore.ObjectEncoder) error) []zapcore.Field {
+	var fields []zapcore.Field
+	for key, values := range inputMap {
+		if len(values) == 0 {
+			// this logic makes it such that "values" is encoded in a manner that matches the actual value, whether that
+			// be nil or empty.
+			fields = append(fields, zap.Any(key, values))
+		} else {
+			fields = append(fields, zap.Object(key, zapcore.ObjectMarshalerFunc(func(enc zapcore.ObjectEncoder) error {
+				keys := make([]string, 0, len(values))
+				for k := range values {
+					keys = append(keys, k)
 				}
-			}
-			return nil
-		})))
+				sort.Strings(keys)
+				for _, k := range keys {
+					if err := valFn(k, values[k], enc); err != nil {
+						return err
+					}
+				}
+				return nil
+			})))
+		}
 	}
 	return fields
 }

--- a/wlog-zap/logger_test.go
+++ b/wlog-zap/logger_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/palantir/witchcraft-go-logging/wlog"
+	wlogzap "github.com/palantir/witchcraft-go-logging/wlog-zap"
 	zapimpl "github.com/palantir/witchcraft-go-logging/wlog-zap/internal"
 	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/audit2log"
 	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/audit2log/audit2logtests"
@@ -34,9 +35,16 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log/svc1logtests"
 	"github.com/palantir/witchcraft-go-logging/wlog/trclog/trc1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/trclog/trc1log/trc1logtests"
+	"github.com/palantir/witchcraft-go-logging/wlog/wlogtests"
 	"github.com/palantir/witchcraft-go-logging/wlog/wrappedlog/wrapped1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/wrappedlog/wrapped1log/wrapped1logtests"
 )
+
+func TestWLog(t *testing.T) {
+	wlogtests.JSONTestSuite(t, func(w io.Writer) wlog.Logger {
+		return wlogzap.LoggerProvider().NewLogger(w)
+	})
+}
 
 func TestSvc1Log(t *testing.T) {
 	svc1logtests.JSONTestSuite(t, func(w io.Writer, level wlog.LogLevel, origin string) svc1log.Logger {

--- a/wlog-zerolog/internal/logger.go
+++ b/wlog-zerolog/internal/logger.go
@@ -21,135 +21,100 @@ import (
 	"github.com/rs/zerolog"
 )
 
+var _ wlog.LogEntry = (*zeroLogEntry)(nil)
+
+// zeroLogEntryOp represents a single operation that operates on a *zeroLogEntry.
+// The function does not take a parameter because it should be captured.
+type zeroLogEntryOp func()
+
 type zeroLogEntry struct {
-	evt             *zerolog.Event
-	keys            map[string]struct{}
-	stringMapValues map[string]map[string]string
-	anyMapValues    map[string]map[string]interface{}
+	evt *zerolog.Event
+
+	// a map from key to the operation that should be applied to the *zerolog.Event for that key.
+	// This is needed because *zerolog.Event itself is append-only/set-once, but the wlog.LogEntry interface defines
+	// overwrite behavior.
+	entryOps map[string]zeroLogEntryOp
+
+	// stores values for StringMapValue and AnyMapValue
+	mapValueEntries wlog.MapValueEntries
 }
 
-func (e *zeroLogEntry) keyExists(key string) bool {
-	if _, exists := e.keys[key]; exists {
-		return true
+func zeroLogEntrySetValue[ValT any](entry *zeroLogEntry, fn func(k string, v ValT) *zerolog.Event, k string, v ValT) {
+	entry.delete(k)
+	entry.entryOps[k] = func() {
+		entry.evt = fn(k, v)
 	}
-	e.keys[key] = struct{}{}
-	return false
 }
 
-func (e *zeroLogEntry) StringValue(key, value string) {
-	if e.keyExists(key) {
-		return
-	}
-	e.evt = e.evt.Str(key, value)
+func (e *zeroLogEntry) delete(k string) {
+	delete(e.entryOps, k)
+	e.mapValueEntries.Delete(k)
+}
+
+func (e *zeroLogEntry) StringValue(k, v string) {
+	zeroLogEntrySetValue(e, e.evt.Str, k, v)
 }
 
 func (e *zeroLogEntry) OptionalStringValue(key, value string) {
-	if value != "" {
+	if value == "" {
+		e.delete(key)
+	} else {
 		e.StringValue(key, value)
 	}
 }
 
 func (e *zeroLogEntry) StringListValue(k string, v []string) {
-	if len(v) > 0 {
-		if e.keyExists(k) {
-			return
-		}
-		e.evt.Strs(k, v)
+	if v == nil {
+		v = make([]string, 0)
 	}
+	zeroLogEntrySetValue(e, e.evt.Strs, k, v)
 }
 
-func (e *zeroLogEntry) SafeLongValue(key string, value int64) {
-	if e.keyExists(key) {
-		return
-	}
-	e.evt = e.evt.Int64(key, value)
+func (e *zeroLogEntry) SafeLongValue(k string, v int64) {
+	zeroLogEntrySetValue(e, e.evt.Int64, k, v)
 }
 
-func (e *zeroLogEntry) IntValue(key string, value int32) {
-	if e.keyExists(key) {
-		return
-	}
-	e.evt = e.evt.Int32(key, value)
+func (e *zeroLogEntry) IntValue(k string, v int32) {
+	zeroLogEntrySetValue(e, e.evt.Int32, k, v)
 }
 
 func (e *zeroLogEntry) ObjectValue(k string, v interface{}, marshalerType reflect.Type) {
-	if e.keyExists(k) {
-		return
-	}
-	e.evt.Interface(k, v)
+	zeroLogEntrySetValue(e, e.evt.Interface, k, v)
 }
 
-// StringMapValue adds or merges the strings in values
-// Since wlog overrides duplicates with a preference for the last parameter
-// The parameters should not replace an existing key because parameters are passed to zerolog in reverse
-// This differs from the default wlog StringMapValue since parameters are not reversed
 func (e *zeroLogEntry) StringMapValue(key string, values map[string]string) {
-	if len(values) == 0 {
-		return
-	}
-	if e.stringMapValues == nil {
-		e.stringMapValues = make(map[string]map[string]string)
-	}
-	entryMapVals, ok := e.stringMapValues[key]
-	if !ok {
-		entryMapVals = make(map[string]string)
-		e.stringMapValues[key] = entryMapVals
-	}
-	for k, v := range values {
-		if _, exists := entryMapVals[k]; !exists {
-			entryMapVals[k] = v
-		}
-	}
+	delete(e.entryOps, key)
+	e.mapValueEntries.StringMapValue(key, values)
 }
 
-// AnyMapValue adds or merges the values in values
-// Since wlog overrides duplicates with a preference for the last parameter
-// The parameters should not replace an existing key because parameters are passed to zerolog in reverse
-// This differs from the default wlog AnyMapValue since parameters are not reversed
 func (e *zeroLogEntry) AnyMapValue(key string, values map[string]interface{}) {
-	if len(values) == 0 {
-		return
-	}
-	if e.anyMapValues == nil {
-		e.anyMapValues = make(map[string]map[string]interface{})
-	}
-	entryMapVals, ok := e.anyMapValues[key]
-	if !ok {
-		entryMapVals = make(map[string]interface{})
-		e.anyMapValues[key] = entryMapVals
-	}
-	for k, v := range values {
-		if _, exists := entryMapVals[k]; !exists {
-			entryMapVals[k] = v
-		}
-	}
-}
-
-func (e *zeroLogEntry) StringMapValues() map[string]map[string]string {
-	return e.stringMapValues
-}
-
-func (e *zeroLogEntry) AnyMapValues() map[string]map[string]interface{} {
-	return e.anyMapValues
+	delete(e.entryOps, key)
+	e.mapValueEntries.AnyMapValue(key, values)
 }
 
 func (e *zeroLogEntry) Evt() *zerolog.Event {
 	evt := e.evt
-	for key, values := range e.StringMapValues() {
-		key := key
-		values := values
-		dictEvt := zerolog.Dict()
-		for k, v := range values {
-			dictEvt = dictEvt.Str(k, v)
-		}
-		evt = evt.Dict(key, dictEvt)
+
+	for _, opFn := range e.entryOps {
+		opFn()
 	}
-	for key, values := range e.AnyMapValues() {
-		key := key
-		values := values
+
+	evt = addMapToEvt(evt, e.mapValueEntries.StringMapValues(), func(dictEvt *zerolog.Event, k string, v string) *zerolog.Event {
+		return dictEvt.Str(k, v)
+	})
+
+	evt = addMapToEvt(evt, e.mapValueEntries.AnyMapValues(), func(dictEvt *zerolog.Event, k string, v any) *zerolog.Event {
+		return dictEvt.Interface(k, v)
+	})
+
+	return evt
+}
+
+func addMapToEvt[ValT any](evt *zerolog.Event, inputMap map[string]map[string]ValT, evtFn func(dictEvt *zerolog.Event, k string, v ValT) *zerolog.Event) *zerolog.Event {
+	for key, values := range inputMap {
 		dictEvt := zerolog.Dict()
 		for k, v := range values {
-			dictEvt = dictEvt.Interface(k, v)
+			dictEvt = evtFn(dictEvt, k, v)
 		}
 		evt = evt.Dict(key, dictEvt)
 	}
@@ -189,21 +154,14 @@ func (l *zeroLogger) Error(msg string, params ...wlog.Param) {
 	}
 }
 
-func reverseParams(params []wlog.Param) {
-	for i, j := 0, len(params)-1; i < j; i, j = i+1, j-1 {
-		params[i], params[j] = params[j], params[i]
-	}
-}
-
 func logOutput(newEvt func() *zerolog.Event, msg string, params []wlog.Param) {
 	entry := &zeroLogEntry{
-		evt:  newEvt(),
-		keys: make(map[string]struct{}),
+		evt:      newEvt(),
+		entryOps: make(map[string]zeroLogEntryOp),
 	}
 	if !entry.evt.Enabled() {
 		return
 	}
-	reverseParams(params)
 	wlog.ApplyParams(entry, params)
 	entry.Evt().Msg(msg)
 }

--- a/wlog-zerolog/logger_test.go
+++ b/wlog-zerolog/logger_test.go
@@ -34,9 +34,16 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log/svc1logtests"
 	"github.com/palantir/witchcraft-go-logging/wlog/trclog/trc1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/trclog/trc1log/trc1logtests"
+	"github.com/palantir/witchcraft-go-logging/wlog/wlogtests"
 	"github.com/palantir/witchcraft-go-logging/wlog/wrappedlog/wrapped1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/wrappedlog/wrapped1log/wrapped1logtests"
 )
+
+func TestWLog(t *testing.T) {
+	wlogtests.JSONTestSuite(t, func(w io.Writer) wlog.Logger {
+		return wlogzerolog.LoggerProvider().NewLogger(w)
+	})
+}
 
 func TestSvc1Log(t *testing.T) {
 	svc1logtests.JSONTestSuite(t, func(w io.Writer, level wlog.LogLevel, origin string) svc1log.Logger {

--- a/wlog/logentry.go
+++ b/wlog/logentry.go
@@ -16,22 +16,80 @@ package wlog
 
 import (
 	"io"
+	"maps"
 	"reflect"
 )
 
+// LogEntry is an interface that represents a log entry, which is an entry on which a key-value pair can be set.
 type LogEntry interface {
+	// StringValue sets the value for the specified key to be the specified value.
+	// Overwrites any previous value associated with the key.
 	StringValue(k, v string)
-	OptionalStringValue(k, v string)
-	SafeLongValue(k string, v int64)
-	IntValue(k string, v int32)
-	StringListValue(k string, v []string)
-	StringMapValue(k string, v map[string]string)
-	AnyMapValue(k string, v map[string]interface{})
 
-	// ObjectValue logs the provided value associated with the specified key. If marshalerType is non-nil, then if a
-	// custom marshaler is registered for that type, it may be used to log the entry. If marshalerType is nil or no
-	// marshaler is registered for the provided type, the entry should be logged using reflection.
-	ObjectValue(k string, v interface{}, marshalerType reflect.Type)
+	// OptionalStringValue sets the value for the specified key to be the specified value *if* the provided value
+	// is non-empty. If the provided value is empty, this operation removes the key.
+	// Overwrites any previous value associated with the key if the provided value is non-empty. If the provided value
+	// is empty, this operation removes the key.
+	//
+	// Note that these semantics mean that it is not possible to use this function to associate the empty string value
+	// ("") with a key: if this behavior is desired, call the StringValue function with an empty string instead.
+	OptionalStringValue(k, v string)
+
+	// SafeLongValue sets the value for the specified key to be the specified value.
+	// Overwrites any previous value associated with the key.
+	SafeLongValue(k string, v int64)
+
+	// IntValue sets the value for the specified key to be the specified value.
+	// Overwrites any previous value associated with the key.
+	IntValue(k string, v int32)
+
+	// StringListValue sets the value for the specified key to be the specified value. If the provided value is empty or
+	// nil, sets the value for the specified key to be an empty array.
+	// Overwrites any previous value associated with the key.
+	StringListValue(k string, v []string)
+
+	// StringMapValue sets the value for the specified key to be a map that contains all the entries in the provided
+	// map.
+	//
+	// - If there is no value for the specified key, the value is set to be a map that contains all the entries in the
+	//   provided map (if the provided map is nil or empty, the result is an empty map).
+	// - If the existing value for the specified key is a map constructed from previous calls to StringMapValue, the
+	//   entries in the provided map are merged with the existing entries. In this case, if there are any entries with
+	//   matching keys, the values in the provided map will overwrite the existing values.
+	// - If the existing value for the specified key is any other value, this call overwrites the value with a map that
+	//   contains the entries in the provided map (if the provided map is nil or empty, this is an empty map).
+	//
+	// Note that these semantics mean that this function cannot remove any keys in the map specified by the provided
+	// key. If a caller wants to ensure that the map for the specified key contains only the elements provided by this
+	// call, a roundabout way of doing so is to call another function like "StringValue" for the same key first, since
+	// that call will overwrite any existing StringMapValue and then the subsequent call to StringMapValue will
+	// overwrite that value.
+	StringMapValue(k string, v map[string]string)
+
+	// AnyMapValue sets the value for the specified key to be a map that contains all the entries in the provided map.
+	// If there is no value for the specified key, the value is set to be a map that contains all the entries in the
+	// provided map (if the provided map is nil or empty, the result is an empty map).
+	//
+	// - If there is no value for the specified key, the value is set to be a map that contains all the entries in the
+	//   provided map (if the provided map is nil or empty, the result is an empty map).
+	// - If the existing value for the specified key is a map constructed from previous calls to AnyMapValue, the
+	//   entries in the provided map are merged with the existing entries. In this case, if there are any entries with
+	//   matching keys, the values in the provided map will overwrite the existing values.
+	// - If the existing value for the specified key is any other value, this call overwrites the value with a map that
+	//   contains the entries in the provided map (if the provided map is nil or empty, this is an empty map).
+	//
+	// Note that these semantics mean that this function cannot remove any keys in the map specified by the provided
+	// key. If a caller wants to ensure that the map for the specified key contains only the elements provided by this
+	// call, a roundabout way of doing so is to call another function like "StringValue" for the same key first, since
+	// that call will overwrite any existing AnyMapValue and then the subsequent call to AnyMapValue will overwrite that
+	// value.
+	AnyMapValue(k string, v map[string]any)
+
+	// ObjectValue sets the value for the specified key to be the specified value. If marshalerType is non-nil, then if
+	// a custom marshaler is registered for that type, it may be used to log the entry. If marshalerType is nil or no
+	// marshaler is registered for the provided type, the entry is logged using reflection.
+	// Overwrites any previous value associated with the key.
+	ObjectValue(k string, v any, marshalerType reflect.Type)
 }
 
 type Logger interface {
@@ -61,38 +119,51 @@ type MapValueEntries struct {
 	anyMapValues    map[string]map[string]interface{}
 }
 
-func (m *MapValueEntries) StringMapValue(key string, values map[string]string) {
-	if len(values) == 0 {
-		return
-	}
-	if m.stringMapValues == nil {
-		m.stringMapValues = make(map[string]map[string]string)
-	}
-	entryMapVals, ok := m.stringMapValues[key]
-	if !ok {
-		entryMapVals = make(map[string]string)
-		m.stringMapValues[key] = entryMapVals
-	}
-	for k, v := range values {
-		entryMapVals[k] = v
-	}
+func (m *MapValueEntries) StringMapValue(k string, v map[string]string) {
+	mapValueEntriesAddValuesToMap(m, &m.stringMapValues, k, v)
 }
 
-func (m *MapValueEntries) AnyMapValue(key string, values map[string]interface{}) {
-	if len(values) == 0 {
-		return
+func (m *MapValueEntries) AnyMapValue(k string, v map[string]interface{}) {
+	mapValueEntriesAddValuesToMap(m, &m.anyMapValues, k, v)
+}
+
+// Delete deletes the specified key from all the maps in the data structure.
+func (m *MapValueEntries) Delete(k string) {
+	delete(m.stringMapValues, k)
+	delete(m.anyMapValues, k)
+}
+
+// mapValueEntriesAddValuesToMap adds the entries in the provided "values" map to the map associated with the provided
+// key in the map of maps referenced by mapValuesPtr.
+//
+// If the value of the provided mapValuesPtr is nil, this function allocates a new map for it.
+//
+// If the map of maps referenced by mapValuesPtr has a map associated with the provided key, the entries in the provided
+// map are merged with the existing values. If there are any entries with matching keys, the values in the provided map
+// will overwrite the existing values.
+//
+// If the map of maps referenced by mapValuesPtr does not have a map associated with the provided key, sets the value of
+// the key to be a new map and then adds all the entries from the provided map. This means that, if the provided map is
+// nil or empty, the result will be that the key will be associated with an empty map.
+func mapValueEntriesAddValuesToMap[ValT any](m *MapValueEntries, mapValuesPtr *map[string]map[string]ValT, k string, v map[string]ValT) {
+	if *mapValuesPtr == nil {
+		*mapValuesPtr = make(map[string]map[string]ValT)
 	}
-	if m.anyMapValues == nil {
-		m.anyMapValues = make(map[string]map[string]interface{})
-	}
-	entryMapVals, ok := m.anyMapValues[key]
+
+	entryMapVals, ok := (*mapValuesPtr)[k]
 	if !ok {
-		entryMapVals = make(map[string]interface{})
-		m.anyMapValues[key] = entryMapVals
+		// if entry does not exist, initialize with an empty map
+		entryMapVals = make(map[string]ValT)
+		(*mapValuesPtr)[k] = entryMapVals
 	}
-	for k, v := range values {
-		entryMapVals[k] = v
-	}
+	// add all provided elements to map
+	maps.Copy(entryMapVals, v)
+
+	// clear key from all maps
+	m.Delete(k)
+
+	// set key on target map
+	(*mapValuesPtr)[k] = entryMapVals
 }
 
 func (m *MapValueEntries) StringMapValues() map[string]map[string]string {

--- a/wlog/logentry_map.go
+++ b/wlog/logentry_map.go
@@ -15,6 +15,7 @@
 package wlog
 
 import (
+	"maps"
 	"reflect"
 )
 
@@ -42,7 +43,6 @@ type ObjectValue struct {
 
 func NewMapLogEntry() MapLogEntry {
 	return &mapLogEntry{
-		allKeys:          make(map[string]struct{}),
 		stringValues:     make(map[string]string),
 		safeLongValues:   make(map[string]int64),
 		intValues:        make(map[string]int32),
@@ -57,7 +57,6 @@ func NewMapLogEntry() MapLogEntry {
 // stores a single value for a given key -- if multiple calls are made with the same key, only the last value is stored.
 // If multiple map values are provided for the same key, the map values are merged.
 type mapLogEntry struct {
-	allKeys          map[string]struct{}
 	stringValues     map[string]string
 	safeLongValues   map[string]int64
 	intValues        map[string]int32
@@ -67,13 +66,22 @@ type mapLogEntry struct {
 	objectValues     map[string]ObjectValue
 }
 
-func (le *mapLogEntry) clearKey(key string) {
-	delete(le.allKeys, key)
-	delete(le.stringValues, key)
-	delete(le.safeLongValues, key)
-	delete(le.intValues, key)
-	delete(le.stringMapValues, key)
-	delete(le.anyMapValues, key)
+func (le *mapLogEntry) delete(k string) {
+	delete(le.stringValues, k)
+	delete(le.safeLongValues, k)
+	delete(le.intValues, k)
+	delete(le.stringListValues, k)
+	delete(le.stringMapValues, k)
+	delete(le.anyMapValues, k)
+	delete(le.objectValues, k)
+}
+
+// mapLogEntrySetKey sets the key in the provided map to be the provided value. The provided map should be a map in the
+// provided mapLogEntry. Also ensure that the provided mapLogEntry is updated so that, if the key was previously
+// assigned for any other value type, it is unassigned.
+func mapLogEntrySetKey[ValT any](le *mapLogEntry, m map[string]ValT, k string, val ValT) {
+	le.delete(k)
+	m[k] = val
 }
 
 func (le *mapLogEntry) StringValues() map[string]string {
@@ -105,87 +113,59 @@ func (le *mapLogEntry) ObjectValues() map[string]ObjectValue {
 }
 
 func (le *mapLogEntry) StringValue(k, v string) {
-	le.clearKey(k)
-
-	le.allKeys[k] = struct{}{}
-	le.stringValues[k] = v
+	mapLogEntrySetKey(le, le.stringValues, k, v)
 }
 
 func (le *mapLogEntry) StringListValue(k string, v []string) {
-	le.clearKey(k)
-
-	le.allKeys[k] = struct{}{}
-	le.stringListValues[k] = v
+	mapLogEntrySetKey(le, le.stringListValues, k, v)
 }
 
 func (le *mapLogEntry) OptionalStringValue(k, v string) {
-	if v != "" {
+	if v == "" {
+		le.delete(k)
+	} else {
 		le.StringValue(k, v)
 	}
 }
 
 func (le *mapLogEntry) SafeLongValue(k string, v int64) {
-	le.clearKey(k)
-
-	le.allKeys[k] = struct{}{}
-	le.safeLongValues[k] = v
+	mapLogEntrySetKey(le, le.safeLongValues, k, v)
 }
 
 func (le *mapLogEntry) IntValue(k string, v int32) {
-	le.clearKey(k)
-
-	le.allKeys[k] = struct{}{}
-	le.intValues[k] = v
+	mapLogEntrySetKey(le, le.intValues, k, v)
 }
 
 func (le *mapLogEntry) StringMapValue(k string, v map[string]string) {
-	prevStringMapVal := le.stringMapValues[k]
-	le.clearKey(k)
-	le.allKeys[k] = struct{}{}
-
-	var newMapVal map[string]string
-	if len(prevStringMapVal) == 0 {
-		newMapVal = v
-	} else {
-		newMapVal = make(map[string]string)
-		for prevK, prevV := range prevStringMapVal {
-			newMapVal[prevK] = prevV
-		}
-		for newK, newV := range v {
-			newMapVal[newK] = newV
-		}
-	}
-	le.stringMapValues[k] = newMapVal
+	mapLogEntryAddValuesToMap(le, le.stringMapValues, k, v)
 }
 
 func (le *mapLogEntry) AnyMapValue(k string, v map[string]interface{}) {
-	prevAnyMapVal := le.anyMapValues[k]
-	le.clearKey(k)
-	le.allKeys[k] = struct{}{}
+	mapLogEntryAddValuesToMap(le, le.anyMapValues, k, v)
+}
 
-	var newMapVal map[string]interface{}
-	if len(prevAnyMapVal) == 0 {
-		newMapVal = v
-	} else {
-		newMapVal = make(map[string]interface{})
-		for prevK, prevV := range prevAnyMapVal {
-			newMapVal[prevK] = prevV
-		}
-		for newK, newV := range v {
-			newMapVal[newK] = newV
-		}
+func mapLogEntryAddValuesToMap[ValT any](m *mapLogEntry, mapValues map[string]map[string]ValT, k string, v map[string]ValT) {
+	entryMapVals, ok := mapValues[k]
+	if !ok {
+		// if entry does not exist, initialize with an empty map
+		entryMapVals = make(map[string]ValT)
+		mapValues[k] = entryMapVals
 	}
-	le.anyMapValues[k] = newMapVal
+	// add all provided elements to map
+	maps.Copy(entryMapVals, v)
+
+	// clear key from all maps
+	m.delete(k)
+
+	// set key on target map
+	mapValues[k] = entryMapVals
 }
 
 func (le *mapLogEntry) ObjectValue(k string, v interface{}, marshalerType reflect.Type) {
-	le.clearKey(k)
-
-	le.allKeys[k] = struct{}{}
-	le.objectValues[k] = ObjectValue{
+	mapLogEntrySetKey(le, le.objectValues, k, ObjectValue{
 		Value:         v,
 		MarshalerType: marshalerType,
-	}
+	})
 }
 
 func (le *mapLogEntry) Apply(logEntry LogEntry) {

--- a/wlog/logger_provider_noop.go
+++ b/wlog/logger_provider_noop.go
@@ -25,6 +25,8 @@ func NewNoopLoggerProvider() LoggerProvider {
 	return &noopLoggerProvider{}
 }
 
+var _ LogEntry = (*noopLogEntry)(nil)
+
 type nooplogger struct{}
 
 func (*nooplogger) Log(params ...Param)               {}

--- a/wlog/wlogtests/tests.go
+++ b/wlog/wlogtests/tests.go
@@ -1,0 +1,435 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wlogtests
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/palantir/pkg/objmatcher"
+	"github.com/palantir/pkg/safejson"
+	"github.com/palantir/witchcraft-go-logging/wlog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type EntryTestCase struct {
+	Name string
+
+	EntryFn func(entry wlog.LogEntry)
+	Matcher objmatcher.MapMatcher
+}
+
+func JSONTestSuite(t *testing.T, loggerProvider func(w io.Writer) wlog.Logger) {
+	// Verifies behavior of basic log entry operations
+	runEntryTestCases(t, "basic tests", basicTestCases(), loggerProvider)
+
+	// Verifies that if different parameters are specified using Value and Values params, all of the values are present
+	// in the final output (that is, these parameters should be additive)
+	runEntryTestCases(t, "set same key tests", setSameKeyTestCases(), loggerProvider)
+}
+
+func basicTestCases() []EntryTestCase {
+	return []EntryTestCase{
+		{
+			Name: "OptionalStringValue that is non-empty sets value",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.OptionalStringValue("test-key", "test-optional-string-value")
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher("test-optional-string-value"),
+			},
+		},
+		{
+			Name: "OptionalStringValue that is empty is a noop",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.OptionalStringValue("test-key", "")
+			},
+			Matcher: map[string]objmatcher.Matcher{},
+		},
+		{
+			Name: "StringList writes array values",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringListValue("test-key", []string{"one", "two"})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.SliceMatcher([]objmatcher.Matcher{
+					objmatcher.NewEqualsMatcher("one"),
+					objmatcher.NewEqualsMatcher("two"),
+				}),
+			},
+		},
+		{
+			Name: "StringList that is empty writes empty array",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringListValue("test-key", []string{})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher([]any{}),
+			},
+		},
+		{
+			Name: "StringList that is nil writes empty array",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringListValue("test-key", nil)
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher([]any{}),
+			},
+		},
+		{
+			Name: "StringMapValue writes map values",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringMapValue("test-key", map[string]string{
+					"one": "two",
+				})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.MapMatcher{
+					"one": objmatcher.NewEqualsMatcher("two"),
+				},
+			},
+		},
+		{
+			Name: "StringMapValue that is empty writes empty map",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringMapValue("test-key", map[string]string{})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher(map[string]any{}),
+			},
+		},
+		{
+			Name: "StringMapValue that is nil writes empty map",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringMapValue("test-key", nil)
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher(map[string]any{}),
+			},
+		},
+		{
+			Name: "AnyMapValue writes map values",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.AnyMapValue("test-key", map[string]any{
+					"one": 2,
+				})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.MapMatcher{
+					"one": objmatcher.NewEqualsMatcher(json.Number("2")),
+				},
+			},
+		},
+		{
+			Name: "AnyMapValue that is empty writes empty map",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.AnyMapValue("test-key", map[string]any{})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher(map[string]any{}),
+			},
+		},
+		{
+			Name: "AnyMapValue that is nil writes empty map",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.AnyMapValue("test-key", nil)
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher(map[string]any{}),
+			},
+		},
+	}
+}
+
+func setSameKeyTestCases() []EntryTestCase {
+	return []EntryTestCase{
+		{
+			Name: "IntValue overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.IntValue("test-key", 1)
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher(json.Number("1")),
+			},
+		},
+		{
+			Name: "SafeLongValue overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.SafeLongValue("test-key", 1)
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher(json.Number("1")),
+			},
+		},
+		{
+			Name: "StringValue overrides IntValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.IntValue("test-key", 1)
+
+				entry.StringValue("test-key", "test-string-value")
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher("test-string-value"),
+			},
+		},
+		{
+			Name: "StringValue overrides StringMapValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringMapValue("test-key", map[string]string{
+					"string-map-key-1": "string-map-value-1",
+					"string-map-key-2": "string-map-value-2",
+				})
+
+				entry.StringValue("test-key", "test-string-value")
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher("test-string-value"),
+			},
+		},
+		{
+			Name: "StringValue overrides AnyMapValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.AnyMapValue("test-key", map[string]any{
+					"any-map-key-1": "any-map-value-1",
+					"any-map-key-2": 2,
+				})
+
+				entry.StringValue("test-key", "test-string-value")
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher("test-string-value"),
+			},
+		},
+		{
+			Name: "OptionalStringValue overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.OptionalStringValue("test-key", "test-optional-string-value")
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher("test-optional-string-value"),
+			},
+		},
+		{
+			Name: "OptionalStringValue that is empty deletes key",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.OptionalStringValue("test-key", "")
+			},
+			Matcher: map[string]objmatcher.Matcher{},
+		},
+		{
+			Name: "StringListValue overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.StringListValue("test-key", []string{"test-string-list-value"})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.SliceMatcher([]objmatcher.Matcher{
+					objmatcher.NewEqualsMatcher("test-string-list-value"),
+				}),
+			},
+		},
+		{
+			Name: "StringListValue that is empty overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.StringListValue("test-key", []string{})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher([]any{}),
+			},
+		},
+		{
+			Name: "StringListValue that is nil overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.StringListValue("test-key", nil)
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher([]any{}),
+			},
+		},
+		{
+			Name: "StringMapValue overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.StringMapValue("test-key", map[string]string{
+					"string-map-key-1": "string-map-value-1",
+					"string-map-key-2": "string-map-value-2",
+				})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.MapMatcher(map[string]objmatcher.Matcher{
+					"string-map-key-1": objmatcher.NewEqualsMatcher("string-map-value-1"),
+					"string-map-key-2": objmatcher.NewEqualsMatcher("string-map-value-2"),
+				}),
+			},
+		},
+		{
+			Name: "StringMapValue that is empty overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.StringMapValue("test-key", map[string]string{})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher(map[string]any{}),
+			},
+		},
+		{
+			Name: "StringMapValue that is nil overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.StringMapValue("test-key", nil)
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher(map[string]any{}),
+			},
+		},
+		{
+			Name: "StringMapValue overrides AnyMapValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.AnyMapValue("test-key", map[string]any{
+					"shared-key-1":       1,
+					"shared-key-2":       2,
+					"any-map-key-unique": 3,
+				})
+
+				entry.StringMapValue("test-key", map[string]string{
+					"shared-key-1":          "string-map-value-1",
+					"shared-key-2":          "string-map-value-2",
+					"string-map-key-unique": "string-map-value-3",
+				})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.MapMatcher(map[string]objmatcher.Matcher{
+					"shared-key-1":          objmatcher.NewEqualsMatcher("string-map-value-1"),
+					"shared-key-2":          objmatcher.NewEqualsMatcher("string-map-value-2"),
+					"string-map-key-unique": objmatcher.NewEqualsMatcher("string-map-value-3"),
+				}),
+			},
+		},
+		{
+			Name: "AnyMapValue overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.AnyMapValue("test-key", map[string]any{
+					"string-map-key-1": 1,
+					"string-map-key-2": 2,
+				})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.MapMatcher(map[string]objmatcher.Matcher{
+					"string-map-key-1": objmatcher.NewEqualsMatcher(json.Number("1")),
+					"string-map-key-2": objmatcher.NewEqualsMatcher(json.Number("2")),
+				}),
+			},
+		},
+		{
+			Name: "AnyMapValue that is empty overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.AnyMapValue("test-key", map[string]any{})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher(map[string]any{}),
+			},
+		},
+		{
+			Name: "AnyMapValue that is nil overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.AnyMapValue("test-key", nil)
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher(map[string]any{}),
+			},
+		},
+		{
+			Name: "AnyMapValue overrides StringMapValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringMapValue("test-key", map[string]string{
+					"shared-key-1":          "string-map-value-1",
+					"shared-key-2":          "string-map-value-2",
+					"string-map-key-unique": "string-map-value-3",
+				})
+
+				entry.AnyMapValue("test-key", map[string]any{
+					"shared-key-1":       1,
+					"shared-key-2":       2,
+					"any-map-key-unique": 3,
+				})
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.MapMatcher(map[string]objmatcher.Matcher{
+					"shared-key-1":       objmatcher.NewEqualsMatcher(json.Number("1")),
+					"shared-key-2":       objmatcher.NewEqualsMatcher(json.Number("2")),
+					"any-map-key-unique": objmatcher.NewEqualsMatcher(json.Number("3")),
+				}),
+			},
+		},
+		{
+			Name: "ObjectValue overrides StringValue",
+			EntryFn: func(entry wlog.LogEntry) {
+				entry.StringValue("test-key", "test-string-value")
+
+				entry.ObjectValue("test-key", 13, nil)
+			},
+			Matcher: map[string]objmatcher.Matcher{
+				"test-key": objmatcher.NewEqualsMatcher(json.Number("13")),
+			},
+		},
+	}
+}
+
+func runEntryTestCases(t *testing.T, suiteName string, testCases []EntryTestCase, loggerProvider func(w io.Writer) wlog.Logger) {
+	t.Run(suiteName, func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.Name, func(t *testing.T) {
+				var buf bytes.Buffer
+				logger := loggerProvider(&buf)
+
+				param := wlog.NewParam(tc.EntryFn)
+
+				logger.Log(param)
+
+				gotLog := map[string]interface{}{}
+				logEntry := buf.Bytes()
+				err := safejson.Unmarshal(logEntry, &gotLog)
+				require.NoError(t, err, "Log line is not a valid map: %v", string(logEntry))
+
+				assert.NoError(t, tc.Matcher.Matches(gotLog))
+			})
+		}
+	})
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates the LogEntry API by clarifying the semantics/behavior of
calls that operate on the same key as previous calls and updates
implementations to match the specified behavior.

The updated API clarifies that a call to any function will result
in the specified key being set and overwriting any previous value
associated with the key (with the narrow exception of "*MapValue"
functions, which will merge/add values if the existing value for
the key was set by the same function).

Also adds a test suite that verifies the wlog behavior and runs
the test suite for the zap and zerolog implementations.

The updated API changes existing behavior as follows:
* Previously, calling "OptionalStringValue" with an empty value
  was a noop. This meant that, if the provided key already had a
  value associated with it, it would continue to be associated with it.
  The API contract and behavior has been updated such that the behavior is
  to remove the value for the key instead.
* Previously, calling "StringListValue" with a nil or empty slice
  was a noop. This meant that, if the provided key already had a
  value associated with it, it would continue to be associated with it.
  The API contract and behavior has been updated such that the behavior is
  to set the value to an empty slice instead.
* Previously, implementations had inconsistent/confusing behavior if the
  same key was set using "StringMapValue", "AnyMapValue", and another setter.
  In a scenario where a key was set using all 3 functions, the previous implementation
  would always log the value for "AnyMapValue", regardless of the order in which the
  calls were made. This ambiguity has been removed by specifying sensible behavior
  at the interface API level and ensuring that all implementations adhere to it.

Updating the API contract and implementation also allowed the zerolog
implementation to be simplified: previously, the zerolog logger implementation
tracked Param inputs and applied them in reverse, which worked, but was confusing
and introduced implicit behavioral assumptions between packages. With the LogEntry
API updates, the zerolog logger implementation has been updated to be more straightforward.

This change also uses generics to reduce code duplication.
==COMMIT_MSG==

## Possible downsides?
Although I believe these API changes are strictly for the better, it does modify existing behavior, which introduces a risk of regression. However, based on the changes and the manner in which `LogEntry` was used, I don't believe the risk here is very high -- the biggest functional change is making `OptionalStringValue` delete the key for an empty optional (rather than it being a noop), but I don't believe that there are many such uses with possible key collisions.

The `zap` logging implementation is a hot path, and this change modifies the code to adds an extra function call to facilitate code reuse using generics. Although any hot-path modification poses a risk, the core logic is unchanged and generics are resolved to native code at compile-time, so I don't anticipate this changing performance characteristics in any noticeable manner.