### PR TITLE
Improvement: Limit safe loggable types

### DIFF
--- a/adapters/svc1zap/svc1zap.go
+++ b/adapters/svc1zap/svc1zap.go
@@ -58,13 +58,6 @@ func WithOriginFromZapCaller() Option {
 	return func(core *svc1zapCore) { core.originFromCallLine = true }
 }
 
-// WithNewParamFunc provides a function for constructing svc1log.Param values from zap fields.
-// Use this option to control parameter safety. By default, all fields are converted to unsafe params.
-// If newParam returns nil, the field is skipped.
-func WithNewParamFunc(newParam func(key string, value interface{}) svc1log.Param) Option {
-	return func(core *svc1zapCore) { core.newParamFunc = newParam }
-}
-
 // WithEntryMutatorFunc provides a function for modifying or skipping entries dynamically.
 // If mutator is set, ok must return true for the message to be logged.
 func WithEntryMutatorFunc(mutator func(entry zapcore.Entry) (out zapcore.Entry, ok bool)) Option {

--- a/adapters/svc1zap/svc1zap_test.go
+++ b/adapters/svc1zap/svc1zap_test.go
@@ -17,7 +17,6 @@ package svc1zap
 import (
 	"bytes"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/palantir/pkg/objmatcher"
@@ -33,16 +32,6 @@ import (
 
 func TestSvc1ZapWrapper(t *testing.T) {
 
-	prefixParamFunc := func(key string, value interface{}) svc1log.Param {
-		if strings.HasPrefix(key, "safe") {
-			return svc1log.SafeParam(key, value)
-		}
-		if !strings.HasPrefix(key, "forbidden") {
-			return svc1log.UnsafeParam(key, value)
-		}
-		return nil
-	}
-
 	t.Run("defaults to all unsafe params", func(t *testing.T) {
 		buf := new(bytes.Buffer)
 		logger := svc1log.New(buf, wlog.DebugLevel)
@@ -57,28 +46,6 @@ func TestSvc1ZapWrapper(t *testing.T) {
 				"forbiddenToken": objmatcher.NewEqualsMatcher("token"),
 				"safeString":     objmatcher.NewEqualsMatcher("string"),
 				"unsafeInt":      objmatcher.NewEqualsMatcher(float64(42)),
-			},
-		})
-	})
-
-	t.Run("caller origin and custom params", func(t *testing.T) {
-		buf := new(bytes.Buffer)
-		logger := svc1log.New(buf, wlog.DebugLevel)
-		logr2 := New(logger, WithOriginFromZapCaller(), WithNewParamFunc(prefixParamFunc))
-		logr2 = logr2.With(zap.String("attached", "value"))
-		logr2.Info("logr 2", zap.String("safeString", "string"), zap.String("forbiddenToken", "token"), zap.Int("unsafeInt", 42))
-		assertLogLine(t, buf.Bytes(), objmatcher.MapMatcher{
-			"level":   objmatcher.NewEqualsMatcher("INFO"),
-			"time":    objmatcher.NewRegExpMatcher(".+"),
-			"message": objmatcher.NewEqualsMatcher("logr 2"),
-			"type":    objmatcher.NewEqualsMatcher(svc1log.TypeValue),
-			"origin":  objmatcher.NewRegExpMatcher("^.+/adapters/svc1zap/svc1zap_test.go:\\d+"),
-			"params": objmatcher.MapMatcher{
-				"safeString": objmatcher.NewEqualsMatcher("string"),
-			},
-			"unsafeParams": objmatcher.MapMatcher{
-				"attached":  objmatcher.NewEqualsMatcher("value"),
-				"unsafeInt": objmatcher.NewEqualsMatcher(float64(42)),
 			},
 		})
 	})

--- a/wlog/svclog/svc1log/params.go
+++ b/wlog/svclog/svc1log/params.go
@@ -18,7 +18,10 @@ import (
 	"path"
 	"runtime"
 	"strconv"
+	"time"
 
+	"github.com/palantir/pkg/rid"
+	"github.com/palantir/pkg/uuid"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/internal/gopath"
 	"github.com/palantir/witchcraft-go-logging/wlog"
@@ -144,7 +147,22 @@ func initLineCaller(skip int) (string, int, bool) {
 	return file, line, ok
 }
 
-func SafeParam(key string, value interface{}) Param {
+type SafeLoggableTypes interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
+		~float32 | ~float64 |
+		~string | []string | ~bool |
+		uuid.UUID | time.Time | rid.ResourceIdentifier |
+		map[string]interface{}
+}
+
+func SafeParam[T SafeLoggableTypes](key string, value T) Param {
+	return SafeParams(map[string]interface{}{
+		key: value,
+	})
+}
+
+func SafeParamSlice[T SafeLoggableTypes](key string, value []T) Param {
 	return SafeParams(map[string]interface{}{
 		key: value,
 	})

--- a/wlog/svclog/svc1log/svc1logtests/tests.go
+++ b/wlog/svclog/svc1log/svc1logtests/tests.go
@@ -421,7 +421,9 @@ func jsonParamsOnlyMarshaledIfLoggedTest(t *testing.T, loggerProvider func(w io.
 		logger := loggerProvider(&bytes.Buffer{}, wlog.InfoLevel, "")
 		// demonstrates that writing to a log at a level that is lower than the logger's level will not marshal the
 		// parameters (if marshal occurred, this would panic).
-		logger.Debug("Test Message", svc1log.SafeParam("testType", jsonMarshalPanicType{}))
+		logger.Debug("Test Message", svc1log.SafeParams(map[string]interface{}{
+			"testType": jsonMarshalPanicType{},
+		}))
 	})
 }
 

--- a/wlog/wapp/fatal.go
+++ b/wlog/wapp/fatal.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	werror "github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/witchcraft-go-logging/conjure/witchcraft-logging-api/witchcraft/api/logging"
 	"github.com/palantir/witchcraft-go-logging/wlog/diaglog/diag1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/evtlog/evt2log"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -83,7 +84,7 @@ func handleRecovered(ctx context.Context, r interface{}, stack []byte) (retErr e
 	if err, ok := r.(error); ok {
 		safeParams, unsafeParams := werror.ParamsFromError(err)
 		svc1log.FromContext(ctx).Error("panic recovered",
-			svc1log.SafeParam("stacktrace", stacktrace),
+			svc1log.SafeParam("stacktrace", threadDumpV1SafeParams(stacktrace)),
 			svc1log.SafeParams(safeParams),
 			svc1log.UnsafeParams(unsafeParams),
 			svc1log.UnsafeParam("recovered", r),
@@ -92,7 +93,7 @@ func handleRecovered(ctx context.Context, r interface{}, stack []byte) (retErr e
 			werror.SafeParam("stacktrace", stacktrace))
 	} else {
 		svc1log.FromContext(ctx).Error("panic recovered",
-			svc1log.SafeParam("stacktrace", stacktrace),
+			svc1log.SafeParam("stacktrace", threadDumpV1SafeParams(stacktrace)),
 			svc1log.UnsafeParam("recovered", r),
 			svc1log.Stacktrace(fmt.Errorf("panic recovered\n\n%s", goroutines)))
 		retErr = werror.ErrorWithContextParams(ctx, "panic recovered",
@@ -103,4 +104,10 @@ func handleRecovered(ctx context.Context, r interface{}, stack []byte) (retErr e
 		evt2log.Value("stacktrace", stacktrace),
 		evt2log.UnsafeParam("recovered", r))
 	return retErr
+}
+
+func threadDumpV1SafeParams(threadDump logging.ThreadDumpV1) map[string]interface{} {
+	return map[string]interface{}{
+		"threads": threadDump.Threads,
+	}
 }

--- a/wlog/wrappedlog/wrapped1log/wrapped1logtests/svc1log_tests.go
+++ b/wlog/wrappedlog/wrapped1log/wrapped1logtests/svc1log_tests.go
@@ -455,7 +455,9 @@ func jsonParamsOnlyMarshaledIfLoggedTest(t *testing.T, loggerProvider func(w io.
 		// demonstrates that writing to a log at a level that is lower than the logger's level will not marshal the
 		// parameters (if marshal occurred, this would panic).
 		assert.NotPanics(t, func() {
-			logger.Debug("Test Message", svc1log.SafeParam("testType", jsonMarshalPanicType{}))
+			logger.Debug("Test Message", svc1log.SafeParams(map[string]interface{}{
+				"testType": jsonMarshalPanicType{},
+			}))
 		})
 	})
 }


### PR DESCRIPTION

==COMMIT_MSG==
Limit safe loggable types
==COMMIT_MSG==

This is a breaking change that would limit the ability for users to directly log arbitrary types including structs as safe params in svc1log. The goal is to reduce the risk of logging unexpected information as underlying data stored in a struct changes through refactors over time. This is breaking enough that it likely requires a V2 bump to the module in order to roll out.

For improved ergonomics, this change also adds a SafeParamSlice function to work around the limitations of expressing type constraints using go generics.

