### PR TITLE
Improvement: Do not emit audit log output when using the default warn logger

### DIFF
--- a/wlog/auditlog/audit2log/default.go
+++ b/wlog/auditlog/audit2log/default.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/palantir/witchcraft-go-logging/wlog"
 	wloginternal "github.com/palantir/witchcraft-go-logging/wlog/internal"
 )
 
@@ -30,22 +29,15 @@ func SetDefaultLoggerCreator(creator func() Logger) {
 var defaultLoggerCreator = func() Logger {
 	return &warnLogger{
 		w: os.Stderr,
-		// store the DefaultLoggerProvider at creation-time so that the output of this logger will be consistent
-		// throughout its lifetime (if the default logger provider is changed after a specific warnLogger is created,
-		// that should not change the creator used for that warnLogger).
-		creator: wlog.DefaultLoggerProvider().NewLogger,
 	}
 }
 
-// warnLogger is a logger that writes a warning to the provided io.Writer whenever its logging function is invoked. When
-// the logging function is invoked, a new logger is created using the wlog.LoggerCreator and a warning is written to the io.Writer.
+// warnLogger is a logger that writes a warning to the provided io.Writer whenever its logging function is invoked.
 type warnLogger struct {
-	w       io.Writer
-	creator wlog.LoggerCreator
+	w io.Writer
 }
 
 func (l *warnLogger) Audit(name string, result AuditResultType, params ...Param) {
-	NewFromCreator(io.Discard, l.creator).Audit(name, result, params...)
 	// Ignore the audit log output to prevent leaking sensitive data
 	_, _ = fmt.Fprintln(l.w, wloginternal.WarnLoggerOutput("audit2log", "", 2))
 }

--- a/wlog/auditlog/audit2log/default.go
+++ b/wlog/auditlog/audit2log/default.go
@@ -15,7 +15,6 @@
 package audit2log
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -39,15 +38,14 @@ var defaultLoggerCreator = func() Logger {
 }
 
 // warnLogger is a logger that writes a warning to the provided io.Writer whenever its logging function is invoked. When
-// the logging function is invoked, a new logger is created using the wlog.LoggerCreator and a warning and the output of
-// the created logger are written to the io.Writer.
+// the logging function is invoked, a new logger is created using the wlog.LoggerCreator and a warning is written to the io.Writer.
 type warnLogger struct {
 	w       io.Writer
 	creator wlog.LoggerCreator
 }
 
 func (l *warnLogger) Audit(name string, result AuditResultType, params ...Param) {
-	buf := &bytes.Buffer{}
-	NewFromCreator(buf, l.creator).Audit(name, result, params...)
-	_, _ = fmt.Fprintln(l.w, wloginternal.WarnLoggerOutput("audit2log", buf.String(), 2))
+	NewFromCreator(io.Discard, l.creator).Audit(name, result, params...)
+	// Ignore the audit log output to prevent leaking sensitive data
+	_, _ = fmt.Fprintln(l.w, wloginternal.WarnLoggerOutput("audit2log", "", 2))
 }

--- a/wlog/auditlog/audit3log/default.go
+++ b/wlog/auditlog/audit3log/default.go
@@ -22,6 +22,10 @@ import (
 	wloginternal "github.com/palantir/witchcraft-go-logging/wlog/internal"
 )
 
+func SetDefaultLoggerCreator(creator func() Logger) {
+	defaultLoggerCreator = creator
+}
+
 var defaultLoggerCreator = func() Logger {
 	return &warnLogger{
 		w: os.Stderr,

--- a/wlog/auditlog/audit3log/default.go
+++ b/wlog/auditlog/audit3log/default.go
@@ -19,29 +19,21 @@ import (
 	"io"
 	"os"
 
-	"github.com/palantir/witchcraft-go-logging/wlog"
 	wloginternal "github.com/palantir/witchcraft-go-logging/wlog/internal"
 )
 
 var defaultLoggerCreator = func() Logger {
 	return &warnLogger{
 		w: os.Stderr,
-		// store the DefaultLoggerProvider at creation-time so that the output of this logger will be consistent
-		// throughout its lifetime (if the default logger provider is changed after a specific warnLogger is created,
-		// that should not change the creator used for that warnLogger).
-		creator: wlog.DefaultLoggerProvider().NewLogger,
 	}
 }
 
-// warnLogger is a logger that writes a warning to the provided io.Writer whenever its logging function is invoked. When
-// the logging function is invoked, a new logger is created using the wlog.LoggerCreator and a warning is written to the io.Writer.
+// warnLogger is a logger that writes a warning to the provided io.Writer whenever its logging function is invoked.
 type warnLogger struct {
-	w       io.Writer
-	creator wlog.LoggerCreator
+	w io.Writer
 }
 
 func (l *warnLogger) Audit(name string, result AuditResultType, params ...Param) {
-	NewFromCreator(io.Discard, l.creator).Audit(name, result, params...)
 	// Ignore the audit log output to prevent leaking sensitive data
 	_, _ = fmt.Fprintln(l.w, wloginternal.WarnLoggerOutput("audit3log", "", 2))
 }

--- a/wlog/auditlog/audit3log/default.go
+++ b/wlog/auditlog/audit3log/default.go
@@ -15,7 +15,6 @@
 package audit3log
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -35,15 +34,14 @@ var defaultLoggerCreator = func() Logger {
 }
 
 // warnLogger is a logger that writes a warning to the provided io.Writer whenever its logging function is invoked. When
-// the logging function is invoked, a new logger is created using the wlog.LoggerCreator and a warning and the output of
-// the created logger are written to the io.Writer.
+// the logging function is invoked, a new logger is created using the wlog.LoggerCreator and a warning is written to the io.Writer.
 type warnLogger struct {
 	w       io.Writer
 	creator wlog.LoggerCreator
 }
 
 func (l *warnLogger) Audit(name string, result AuditResultType, params ...Param) {
-	buf := &bytes.Buffer{}
-	NewFromCreator(buf, l.creator).Audit(name, result, params...)
-	_, _ = fmt.Fprintln(l.w, wloginternal.WarnLoggerOutput("audit3log", buf.String(), 2))
+	NewFromCreator(io.Discard, l.creator).Audit(name, result, params...)
+	// Ignore the audit log output to prevent leaking sensitive data
+	_, _ = fmt.Fprintln(l.w, wloginternal.WarnLoggerOutput("audit3log", "", 2))
 }

--- a/wlog/context_default_test.go
+++ b/wlog/context_default_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/palantir/witchcraft-go-logging/conjure/witchcraft-logging-api/witchcraft/api/logging"
 	"github.com/palantir/witchcraft-go-logging/wlog"
 	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/audit2log"
+	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/audit3log"
 	"github.com/palantir/witchcraft-go-logging/wlog/evtlog/evt2log"
 	"github.com/palantir/witchcraft-go-logging/wlog/metriclog/metric1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -66,9 +67,8 @@ func TestOutputFromContextEmptyContext(t *testing.T) {
 				logger.Audit("TEST_EVT", audit2log.AuditResultSuccess)
 			},
 			validateJSON: func(bytes []byte) {
-				var logEntry logging.AuditLogV2
-				require.NoError(t, json.Unmarshal(bytes, &logEntry))
-				assert.Equal(t, "TEST_EVT", logEntry.Name)
+				// audit2log no longer emits log output when warning about missing logger context
+				// to prevent leaking sensitive data. This validation function is no longer called.
 			},
 			setEmptyLoggerCreator: func() {
 				// set the default logger creator
@@ -78,6 +78,27 @@ func TestOutputFromContextEmptyContext(t *testing.T) {
 					return audit2log.New(ioutil.Discard)
 				})
 			},
+			skipLogOutputVerification: true,
+		},
+		{
+			loggerPkg: "audit3log",
+			performLogging: func() {
+				logger := audit3log.FromContext(context.Background())
+				logger.Audit("TEST_EVT", audit3log.AuditResultSuccess)
+			},
+			validateJSON: func(bytes []byte) {
+				// audit3log no longer emits log output when warning about missing logger context
+				// to prevent leaking sensitive data. This validation function is no longer called.
+			},
+			setEmptyLoggerCreator: func() {
+				// set the default logger creator
+				audit3log.SetDefaultLoggerCreator(func() audit3log.Logger {
+					// technically, a truly no-op writer would implement the logger interface and do nothing, but it is
+					// easier to just return a new logger that writes to a no-op writer.
+					return audit3log.New(ioutil.Discard)
+				})
+			},
+			skipLogOutputVerification: true,
 		},
 		{
 			loggerPkg: "evt2log",
@@ -149,10 +170,11 @@ func TestOutputFromContextEmptyContext(t *testing.T) {
 }
 
 type loggerTestCase struct {
-	loggerPkg             string
-	performLogging        func()
-	validateJSON          func([]byte)
-	setEmptyLoggerCreator func()
+	loggerPkg                 string
+	performLogging            func()
+	validateJSON              func([]byte)
+	setEmptyLoggerCreator     func()
+	skipLogOutputVerification bool
 }
 
 func testFromContextFromEmptyContextForSingleLogger(t *testing.T, tmpDir string, loggerTestCaseInfo loggerTestCase) {
@@ -167,6 +189,7 @@ func testFromContextFromEmptyContextForSingleLogger(t *testing.T, tmpDir string,
 		// the logger created by that function outputs a warning stating that the global logger should be set. As a
 		// result, the over-all logger output to os.Stderr is:
 		// "[WARNING] <logger not set in context>: [WARNING] <global logger provider not set>"
+		// NOTE: audit2log and audit3log no longer emit log output after the warning to prevent leaking sensitive data.
 		{
 			name: "Context with no logger set and no logger provider set returns default stderr warning logger that uses warn-once logger",
 			verify: func(loggerTestCaseInfo loggerTestCase, bytes []byte) {
@@ -177,8 +200,13 @@ func testFromContextFromEmptyContextForSingleLogger(t *testing.T, tmpDir string,
 				loc := firstPortionRegexp.FindStringIndex(logOutput)
 				require.NotNil(t, loc, "Unexpected log output: %s", logOutput)
 
-				got := strings.TrimSuffix(logOutput[loc[1]:], "\n")
-				assert.Equal(t, `[WARNING] Logging operation that uses the default logger provider was performed without specifying a logger provider implementation. To see logger output, set the global logger provider implementation using wlog.SetDefaultLoggerProvider or by importing an implementation. This warning can be disabled by setting the global logger provider to be the noop logger provider using wlog.SetDefaultLoggerProvider(wlog.NewNoopLoggerProvider()).`, got)
+				if loggerTestCaseInfo.skipLogOutputVerification {
+					got := strings.TrimSuffix(logOutput[loc[1]:], "\n")
+					assert.Equal(t, "", got)
+				} else {
+					got := strings.TrimSuffix(logOutput[loc[1]:], "\n")
+					assert.Equal(t, `[WARNING] Logging operation that uses the default logger provider was performed without specifying a logger provider implementation. To see logger output, set the global logger provider implementation using wlog.SetDefaultLoggerProvider or by importing an implementation. This warning can be disabled by setting the global logger provider to be the noop logger provider using wlog.SetDefaultLoggerProvider(wlog.NewNoopLoggerProvider()).`, got)
+				}
 			},
 		},
 		// Because the context has no logger set on it, the defaultLoggerCreator is used. The defaultLoggerCreator has
@@ -200,7 +228,12 @@ func testFromContextFromEmptyContextForSingleLogger(t *testing.T, tmpDir string,
 				loc := firstPortionRegexp.FindStringIndex(logOutput)
 				require.NotNil(t, loc, "Unexpected log output: %s", logOutput)
 
-				loggerTestCaseInfo.validateJSON([]byte(logOutput[loc[1]:]))
+				if loggerTestCaseInfo.skipLogOutputVerification {
+					got := strings.TrimSuffix(logOutput[loc[1]:], "\n")
+					assert.Equal(t, "", got)
+				} else {
+					loggerTestCaseInfo.validateJSON([]byte(logOutput[loc[1]:]))
+				}
 			},
 		},
 		// Because the context has no logger set on it, the defaultLoggerCreator is used. The defaultLoggerCreator has


### PR DESCRIPTION
## Before this PR
If the audit logger is not set on the context, then the warn logger is used which emits a warning log message that contains the full body of the audit log. These can end up in service logs resulting in leaking sensitive data.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Do not emit audit log output when using the default warn logger
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

