### PR TITLE
Add explicit metric log timestamps

### DIFF
--- a/wlog-tmpl/logger.go
+++ b/wlog-tmpl/logger.go
@@ -66,11 +66,13 @@ func (l *tmplLogger) logOutput(params []wlog.Param) {
 }
 
 func (l *tmplLogger) formatOutput(params []wlog.Param) string {
-	params = append(params, wlog.StringParam(wlog.TimeKey, time.Now().Format(time.RFC3339Nano)))
+	paramsWithTime := make([]wlog.Param, len(params)+1)
+	paramsWithTime[0] = wlog.StringParam(wlog.TimeKey, time.Now().Format(time.RFC3339Nano))
+	copy(paramsWithTime[1:], params)
 
 	buf := l.bufferPool.Get()
 	defer l.bufferPool.Put(buf)
-	l.delegate(buf).Log(params...)
+	l.delegate(buf).Log(paramsWithTime...)
 
 	out, err := logentryformatter.FormatLogLine(buf.String(), l.cfg.UnwrapperMap, l.cfg.FormatterMap, l.cfg.Only, l.cfg.Exclude)
 	if err != nil {

--- a/wlog-tmpl/logger_test.go
+++ b/wlog-tmpl/logger_test.go
@@ -102,9 +102,14 @@ func TestLogger(t *testing.T) {
 		{
 			Name: "metric1log",
 			LogFn: func(ctx context.Context) {
-				metric1log.FromContext(ctx).Metric("com.palantir.foo", "gauge", metric1log.Value("value", 1))
+				metric1log.FromContext(ctx).Metric(
+					"com.palantir.foo",
+					"gauge",
+					metric1log.Value("value", 1),
+					metric1log.Time(time.Date(2026, time.September, 2, 12, 34, 56, 789123456, time.UTC)),
+				)
 			},
-			Expected: regexp.MustCompile(`^\[[0-9TZ:.-]+] ? METRIC com.palantir.foo gauge \(value: 1\)$`),
+			Expected: regexp.MustCompile(`^\[2026-09-02T12:34:56.789123456Z] ? METRIC com.palantir.foo gauge \(value: 1\)$`),
 		},
 		{
 			Name: "req2log",

--- a/wlog/logger_provider_jsonmarshal.go
+++ b/wlog/logger_provider_jsonmarshal.go
@@ -63,10 +63,12 @@ func (l *jsonMapLogger) Error(msg string, params ...Param) {
 }
 
 func (l *jsonMapLogger) logOutput(params []Param) {
-	params = append(params, StringParam(TimeKey, time.Now().Format(time.RFC3339Nano)))
+	paramsWithTime := make([]Param, len(params)+1)
+	paramsWithTime[0] = StringParam(TimeKey, time.Now().Format(time.RFC3339Nano))
+	copy(paramsWithTime[1:], params)
 
 	entry := NewMapLogEntry()
-	ApplyParams(entry, params)
+	ApplyParams(entry, paramsWithTime)
 	bytes, _ := json.Marshal(entry.AllValues())
 	_, _ = fmt.Fprintln(l.w, string(bytes))
 }

--- a/wlog/metriclog/metric1log/context_test.go
+++ b/wlog/metriclog/metric1log/context_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/palantir/pkg/objmatcher"
 	"github.com/palantir/witchcraft-go-logging/wlog"
@@ -51,6 +52,18 @@ func TestFromContext(t *testing.T) {
 	})
 	err = matcher.Matches(map[string]any(entries[0]))
 	assert.NoError(t, err, "%v", err)
+}
+
+func TestExplicitTime(t *testing.T) {
+	buf := &bytes.Buffer{}
+	timestamp := time.Date(2026, time.September, 2, 12, 34, 56, 789123456, time.UTC)
+
+	newTestLogger(buf).Metric("com.palantir.metric", "gauge", metric1log.Time(timestamp))
+
+	entries, err := logreader.EntriesFromContent(buf.Bytes())
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, timestamp.Format(time.RFC3339Nano), entries[0]["time"])
 }
 
 // Tests that the logger returned by metric1log.FromContext has UID, SID, TokenID, and OrgID parameters set on it if the context

--- a/wlog/metriclog/metric1log/metric1logtests/tests.go
+++ b/wlog/metriclog/metric1log/metric1logtests/tests.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/palantir/pkg/objmatcher"
 	"github.com/palantir/pkg/safejson"
@@ -38,6 +39,7 @@ type TestCase struct {
 	TokenID      string
 	OrgID        string
 	UnsafeParams map[string]any
+	Time         time.Time
 	JSONMatcher  objmatcher.MapMatcher
 }
 
@@ -50,6 +52,7 @@ func (tc TestCase) Params() []metric1log.Param {
 		metric1log.OrgID(tc.OrgID),
 		metric1log.Tags(tc.Tags),
 		metric1log.UnsafeParams(tc.UnsafeParams),
+		metric1log.Time(tc.Time),
 	}
 }
 
@@ -78,9 +81,10 @@ func TestCases() []TestCase {
 			UnsafeParams: map[string]any{
 				"Password": "HelloWorld!",
 			},
+			Time: time.Date(2026, time.September, 2, 12, 34, 56, 789123456, time.UTC),
 			JSONMatcher: objmatcher.MapMatcher(map[string]objmatcher.Matcher{
 				"metricName": objmatcher.NewEqualsMatcher("com.palantir.deployability.logtrough.iteratorage.millis"),
-				"time":       objmatcher.NewRegExpMatcher(".+"),
+				"time":       objmatcher.NewEqualsMatcher("2026-09-02T12:34:56.789123456Z"),
 				"type":       objmatcher.NewEqualsMatcher("metric.1"),
 				"metricType": objmatcher.NewEqualsMatcher("histogram"),
 				"uid":        objmatcher.NewEqualsMatcher("user-1"),

--- a/wlog/metriclog/metric1log/params.go
+++ b/wlog/metriclog/metric1log/params.go
@@ -15,6 +15,8 @@
 package metric1log
 
 import (
+	"time"
+
 	"github.com/palantir/witchcraft-go-logging/wlog"
 )
 
@@ -48,6 +50,13 @@ func metricNameTypeParam(name, typ string) Param {
 	return paramFunc(func(logger wlog.LogEntry) {
 		logger.StringValue(MetricNameKey, name)
 		logger.StringValue(MetricTypeKey, typ)
+	})
+}
+
+// Time overrides the time at which the metric was recorded. By default, metrics use the time at which they are logged.
+func Time(value time.Time) Param {
+	return paramFunc(func(entry wlog.LogEntry) {
+		entry.StringValue(wlog.TimeKey, value.Format(time.RFC3339Nano))
 	})
 }
 

--- a/wlog/wrappedlog/wrapped1log/wrapped1logtests/metric1log_tests.go
+++ b/wlog/wrappedlog/wrapped1log/wrapped1logtests/metric1log_tests.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/palantir/pkg/objmatcher"
 	"github.com/palantir/pkg/safejson"
@@ -38,6 +39,7 @@ type Metric1TestCase struct {
 	TokenID      string
 	OrgID        string
 	UnsafeParams map[string]any
+	Time         time.Time
 	JSONMatcher  objmatcher.MapMatcher
 }
 
@@ -50,6 +52,7 @@ func (tc Metric1TestCase) Params() []metric1log.Param {
 		metric1log.OrgID(tc.OrgID),
 		metric1log.Tags(tc.Tags),
 		metric1log.UnsafeParams(tc.UnsafeParams),
+		metric1log.Time(tc.Time),
 	}
 }
 
@@ -78,6 +81,7 @@ func Metric1TestCases(entityName, entityVersion string) []Metric1TestCase {
 			UnsafeParams: map[string]any{
 				"Password": "HelloWorld!",
 			},
+			Time: time.Date(2026, time.September, 2, 12, 34, 56, 789123456, time.UTC),
 			JSONMatcher: objmatcher.MapMatcher(map[string]objmatcher.Matcher{
 				"type":          objmatcher.NewEqualsMatcher("wrapped.1"),
 				"entityName":    objmatcher.NewEqualsMatcher(entityName),
@@ -86,7 +90,7 @@ func Metric1TestCases(entityName, entityVersion string) []Metric1TestCase {
 					"type": objmatcher.NewEqualsMatcher("metricLogV1"),
 					"metricLogV1": objmatcher.MapMatcher(map[string]objmatcher.Matcher{
 						"metricName": objmatcher.NewEqualsMatcher("com.palantir.deployability.logtrough.iteratorage.millis"),
-						"time":       objmatcher.NewRegExpMatcher(".+"),
+						"time":       objmatcher.NewEqualsMatcher("2026-09-02T12:34:56.789123456Z"),
 						"type":       objmatcher.NewEqualsMatcher("metric.1"),
 						"metricType": objmatcher.NewEqualsMatcher("histogram"),
 						"uid":        objmatcher.NewEqualsMatcher("user-1"),


### PR DESCRIPTION
## Before this PR

Metric log timestamps are always generated when the log call is made. Callers cannot represent a metric value associated with an earlier time.

## After this PR

Adds metric1log.Time so callers can explicitly set the metric.1 time. The parameter also works for metric logs nested in wrapped.1 payloads.

==COMMIT_MSG==
Add explicit metric log timestamps
==COMMIT_MSG==

## Possible downsides?

Callers can supply timestamps that are stale or out of order. The default behavior remains unchanged unless the new parameter is used.